### PR TITLE
Fix ISR crash and DMA corruption of blob function tables

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,8 +38,24 @@ func (e Error) Error() string {
 			return "espradio: no memory"
 		case C.ESP_ERR_INVALID_ARG:
 			return "espradio: invalid argument"
+		case C.ESP_ERR_TIMEOUT:
+			return "espradio: timeout"
+		case 2:
+			return "espradio: auth expired"
+		case 15:
+			return "espradio: 4-way handshake timeout"
+		case 201:
+			return "espradio: AP not found"
+		case 202:
+			return "espradio: auth failed"
+		case 203:
+			return "espradio: assoc failed"
+		case 204:
+			return "espradio: handshake timeout"
+		case 205:
+			return "espradio: connection failed"
 		default:
-			return "espradio: unknown error"
+			return "espradio: error " + strconv.FormatInt(int64(int32(e)), 10)
 		}
 	}
 }

--- a/esp32c3/isr.c
+++ b/esp32c3/isr.c
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include "espradio.h"
+#include "soc/interrupts.h"
 
 /* ---- Interrupt controller registers (ESP32-C3) ---- */
 
@@ -11,37 +12,71 @@
 #define ESPRADIO_INTC_CLEAR_REG       (*(volatile uint32_t *)(ESPRADIO_INTC_BASE + 0x10Cu))
 #define ESPRADIO_INTC_PRI_REG(n)      (*(volatile uint32_t *)(ESPRADIO_INTC_BASE + 0x114u + (uint32_t)(n) * 4u))
 
-/* Route an interrupt source to a CPU-local interrupt number
- * using the ESP32-C3 interrupt matrix. Priority is currently
- * ignored and configured by ROM/IDF defaults.
- */
+/* Interrupt matrix base: each 32-bit register at offset 4*source routes that
+ * peripheral source to a CPU interrupt number (0 = disabled, 1-31 = active). */
+#define ESPRADIO_INTMTX_BASE          0x600C2000u
+#define ESPRADIO_INTMTX_MAP(source)   (*(volatile uint32_t *)(ESPRADIO_INTMTX_BASE + (uint32_t)(source) * 4u))
+
+/* The CPU interrupt number used for all WiFi peripheral sources.
+ * TinyGo registers its handler on this interrupt via interrupt.New(). */
+#define ESPRADIO_WIFI_CPU_INT  1u
+
+/* Pre-wire WiFi peripheral interrupt sources to the WiFi CPU interrupt.
+ * Must be called before esp_wifi_init so routing is in place before the
+ * blob enables the peripheral-side interrupts.
+ * Matches the approach in esp-wifi (Rust): routing is done once during
+ * our controlled init, and the blob's set_intr calls are no-ops. */
+void espradio_prewire_wifi_interrupts(void) {
+    intr_matrix_set(0, ETS_WIFI_MAC_INTR_SOURCE, ESPRADIO_WIFI_CPU_INT);
+    intr_matrix_set(0, ETS_WIFI_MAC_NMI_SOURCE,  ESPRADIO_WIFI_CPU_INT);
+    intr_matrix_set(0, ETS_WIFI_PWR_INTR_SOURCE, ESPRADIO_WIFI_CPU_INT);
+    intr_matrix_set(0, ETS_WIFI_BB_INTR_SOURCE,  ESPRADIO_WIFI_CPU_INT);
+}
+
+/* No-op: the blob calls set_intr to route peripheral sources to CPU
+ * interrupts, but on RISC-V (ESP32-C3) the routing is already configured
+ * by espradio_prewire_wifi_interrupts(). Letting the blob call
+ * intr_matrix_set at arbitrary times interferes with TinyGo's interrupt
+ * controller state.  The Rust esp-wifi does the same (no-op set_intr). */
 void espradio_set_intr(int32_t cpu_no, uint32_t intr_source, uint32_t intr_num, int32_t intr_prio) {
-    (void)intr_prio;
-    if (cpu_no < 0) {
-        cpu_no = 0;
-    }
-    intr_matrix_set((uint32_t)cpu_no, intr_source, intr_num);
-}
-
-/* Disconnect an interrupt source from its CPU-local interrupt. */
-void espradio_clear_intr(uint32_t intr_source, uint32_t intr_num) {
+    (void)cpu_no;
+    (void)intr_source;
     (void)intr_num;
-    intr_matrix_set(0, intr_source, 0);
+    (void)intr_prio;
 }
 
-/* ROM-level ISR mask/unmask functions for ESP32-C3.
- * We keep these declarations and calls here so that the
- * generic ISR code only depends on espradio_ints_on/off
- * and does not need to know about chip-specific ROM APIs.
- */
-extern void ets_isr_unmask(uint32_t mask);
-extern void ets_isr_mask(uint32_t mask);
+/* No-op: the Rust esp-wifi also no-ops clear_intr. */
+void espradio_clear_intr(uint32_t intr_source, uint32_t intr_num) {
+    (void)intr_source;
+    (void)intr_num;
+}
 
+/* Enable/disable CPU interrupts by directly manipulating the
+ * CPU_INT_ENABLE register instead of calling ROM functions
+ * (ets_isr_unmask / ets_isr_mask) which may have side effects
+ * that conflict with TinyGo's interrupt controller setup. */
 void espradio_ints_on(uint32_t mask) {
-    ets_isr_unmask(mask);
+    ESPRADIO_INTC_ENABLE_REG |= mask;
 }
 
 void espradio_ints_off(uint32_t mask) {
-    ets_isr_mask(mask);
+    ESPRADIO_INTC_ENABLE_REG &= ~mask;
+}
+
+/* Switch CPU interrupt 1 from edge to level type.
+ * Must be called AFTER esp_wifi_init() so the blob's ISR handlers are
+ * registered and can acknowledge the peripheral when a level interrupt
+ * fires.  Without a handler to service the peripheral, a level-asserted
+ * line would cause infinite re-entry.
+ *
+ * Sequence: disable → clear latched edge → switch to level → fence → re-enable.
+ */
+void espradio_wifi_int_to_level(void) {
+    ESPRADIO_INTC_ENABLE_REG &= ~(1u << ESPRADIO_WIFI_CPU_INT);
+    ESPRADIO_INTC_CLEAR_REG  |=  (1u << ESPRADIO_WIFI_CPU_INT);
+    ESPRADIO_INTC_CLEAR_REG  &= ~(1u << ESPRADIO_WIFI_CPU_INT);
+    ESPRADIO_INTC_TYPE_REG   &= ~(1u << ESPRADIO_WIFI_CPU_INT);
+    __asm__ volatile ("fence" ::: "memory");
+    ESPRADIO_INTC_ENABLE_REG |=  (1u << ESPRADIO_WIFI_CPU_INT);
 }
 

--- a/espradio.h
+++ b/espradio.h
@@ -17,6 +17,11 @@ void espradio_prepare_memory_for_wifi(void);
 void espradio_ensure_osi_ptr(void);
 void espradio_coex_adapter_init(void);
 void espradio_call_saved_isr(int32_t n);
+void espradio_call_wifi_isr(void);
+void espradio_prewire_wifi_interrupts(void);
+void espradio_wifi_int_to_level(void);
+void espradio_ints_on(uint32_t mask);
+void espradio_ints_off(uint32_t mask);
 int32_t espradio_queue_send(void *queue, void *item, uint32_t block_time_tick);
 uint32_t espradio_isr_ring_head(void);
 uint32_t espradio_isr_ring_tail(void);
@@ -40,6 +45,8 @@ esp_err_t espradio_ap_set_config(const char *ssid, int ssid_len,
 extern esp_err_t esp_wifi_connect_internal(void);
 
 /* ===== netif (netif.c) ===== */
+void      espradio_netif_init_netstack_cb(void);
+void      espradio_post_start_cb(void);
 esp_err_t espradio_netif_start_rx(int ap_mode);
 int       espradio_netif_rx_available(void);
 uint16_t  espradio_netif_rx_pop(void *dst, uint16_t dst_len);

--- a/examples/ap/main-ap.go
+++ b/examples/ap/main-ap.go
@@ -73,7 +73,7 @@ func main() {
 	println("ap: AP is running on", apIP, "— connect to espradio-ap")
 	go stackLoop(stack)
 	for {
-		time.Sleep(3 * time.Second)
+		time.Sleep(1 * time.Second)
 		rxCb, rxDrop := espradio.NetifRxStats()
 		println("ap: rx_cb=", rxCb, "rx_drop=", rxDrop)
 	}

--- a/examples/connect-and-dhcp/main-dhcp.go
+++ b/examples/connect-and-dhcp/main-dhcp.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	wifiSSID = "Kracozabra"
-	wifiPass = "09655455"
+	wifiSSID = "yourssid"
+	wifiPass = "yourpassword"
 )
 
 func main() {
@@ -16,7 +16,7 @@ func main() {
 
 	println("initializing radio...")
 	err := espradio.Enable(espradio.Config{
-		Logging: espradio.LogLevelNone,
+		Logging: espradio.LogLevelError,
 	})
 	if err != nil {
 		println("could not enable radio:", err)

--- a/examples/scan/main.go
+++ b/examples/scan/main.go
@@ -36,8 +36,10 @@ func main() {
 		println("AP:", ap.SSID, "RSSI", ap.RSSI)
 	}
 
-	println("scan finished")
+	c := 1
 	for {
-		time.Sleep(5 * time.Second)
+		println("scan finished", c)
+		c++
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/isr.c
+++ b/isr.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 /* ---- ISR fn/arg storage ---- */
 
@@ -22,6 +23,24 @@ void espradio_call_saved_isr(int32_t n) {
     __asm__ volatile ("fence" ::: "memory");
     if (n >= 0 && n < 32 && s_isr_fn[n]) {
         s_isr_fn[n](s_isr_arg[n]);
+    }
+    __asm__ volatile ("fence" ::: "memory");
+    s_in_isr = 0;
+}
+
+/* Dispatch all WiFi-related ISR handlers.  The blob registers its ISR
+ * via set_isr(n, fn, arg) where n may be 0 (WIFI_MAC source) or 1.
+ * In Rust esp-wifi both indices map to a single handler object; here
+ * we call every non-NULL entry in the WiFi source range (0-3) so that
+ * no registered handler is missed regardless of which index the blob
+ * chose.  Called from the Go interrupt handler for CPU interrupt 1. */
+void espradio_call_wifi_isr(void) {
+    s_in_isr = 1;
+    __asm__ volatile ("fence" ::: "memory");
+    for (int i = 0; i < 4; i++) {
+        if (s_isr_fn[i]) {
+            s_isr_fn[i](s_isr_arg[i]);
+        }
     }
     __asm__ volatile ("fence" ::: "memory");
     s_in_isr = 0;

--- a/netif.c
+++ b/netif.c
@@ -6,6 +6,110 @@ extern int esp_wifi_internal_tx(wifi_interface_t wifi_if, void *buffer, uint16_t
 extern void esp_wifi_internal_free_rx_buffer(void *buffer);
 extern esp_err_t esp_wifi_get_mac(wifi_interface_t ifx, uint8_t mac[6]);
 
+/* The blob calls through s_netstack_ref / s_netstack_free function-pointer
+ * variables after TX to manage upper-layer buffers.  We use copy semantics
+ * (esp_wifi_internal_tx), so no-ops are correct.  Register via the blob's own
+ * API so both pointers are written inside the blob. */
+extern esp_err_t esp_wifi_internal_reg_netstack_buf_cb(
+    void (*ref)(void *), void (*free)(void *));
+
+static void netstack_buf_ref_noop(void *buf)  { (void)buf; }
+static void netstack_buf_free_noop(void *buf)  { (void)buf; }
+
+/* Several blob-internal function-pointer variables live at fixed DRAM
+ * addresses (assigned in the linker script).  They start as zero.  If the
+ * blob calls through any of them before someone writes a valid address,
+ * we get pc:nil.  Write a safe no-op into every callback-shaped variable
+ * that the blob might call unconditionally. */
+extern void (*g_config_func)(void);
+extern void (*g_net80211_tx_func)(void);
+extern void (*g_timer_func)(void);
+extern void (*s_michael_mic_failure_cb)(void);
+extern void (*wifi_sta_rx_probe_req)(void);
+extern void (*g_tx_done_cb_func)(void);
+extern void (*s_encap_amsdu_func)(void);
+extern void (*mesh_rxcb)(void);
+
+static void blob_cb_noop(void) { }
+
+/* pp_wdev_funcs relocation: the ROM ppTask dispatcher calls through a
+ * heap-allocated function-pointer table (pp_wdev_funcs, 196 entries = 0x310
+ * bytes).  DMA corruption can zero heap entries at runtime → pc:nil crash.
+ * After esp_wifi_start() we copy the table into static .bss and redirect
+ * the ROM pointer there, where DMA cannot reach. */
+#define PP_WDEV_FUNCS_ENTRIES  196
+static uint32_t s_pp_wdev_save[PP_WDEV_FUNCS_ENTRIES];
+
+/* Forward declaration — defined below. */
+static esp_err_t espradio_sta_rxcb(void *buffer, uint16_t len, void *eb);
+
+/* Proper-signature TX-done callback (matches wifi_tx_done_cb_t). */
+typedef void (*wifi_tx_done_cb_t)(uint8_t ifidx, uint8_t *data,
+                                  uint16_t *data_len, bool txStatus);
+extern esp_err_t esp_wifi_set_tx_done_cb(wifi_tx_done_cb_t cb);
+
+static void espradio_tx_done_noop(uint8_t ifidx, uint8_t *data,
+                                  uint16_t *data_len, bool txStatus) {
+    (void)ifidx; (void)data; (void)data_len; (void)txStatus;
+}
+
+static void espradio_patch_blob_cb_vars(void) {
+    /* Patch all callback-shaped blob variables that might still be NULL. */
+    if (!g_config_func)             g_config_func = blob_cb_noop;
+    if (!g_net80211_tx_func)        g_net80211_tx_func = blob_cb_noop;
+    if (!g_timer_func)              g_timer_func = blob_cb_noop;
+    if (!s_michael_mic_failure_cb)  s_michael_mic_failure_cb = blob_cb_noop;
+    if (!wifi_sta_rx_probe_req)     wifi_sta_rx_probe_req = blob_cb_noop;
+    if (!g_tx_done_cb_func)         g_tx_done_cb_func = blob_cb_noop;
+    if (!s_encap_amsdu_func)        s_encap_amsdu_func = blob_cb_noop;
+    if (!mesh_rxcb)                 mesh_rxcb = blob_cb_noop;
+}
+
+void espradio_netif_init_netstack_cb(void) {
+    esp_wifi_internal_reg_netstack_buf_cb(netstack_buf_ref_noop,
+                                          netstack_buf_free_noop);
+    espradio_patch_blob_cb_vars();
+}
+
+/* Called after esp_wifi_start(): re-patch any DRAM variables that
+ * the blob may have reset, register the TX-done callback via the
+ * official API, and register an AP-mode RX callback. */
+void espradio_post_start_cb(void) {
+    espradio_patch_blob_cb_vars();
+    esp_wifi_set_tx_done_cb(espradio_tx_done_noop);
+    /* Disable power save — the blob's PM code (pm_tbtt_process) calls through
+     * OSI function pointers in ways that can crash without a full FreeRTOS
+     * environment.  Matches the Rust esp-wifi approach. */
+    esp_wifi_set_ps(WIFI_PS_NONE);
+    /* Register AP rxcb too (blob may call it even in STA mode). */
+    esp_wifi_internal_reg_rxcb(WIFI_IF_AP, espradio_sta_rxcb);
+
+    /* Check whether the blob moved g_osi_funcs_p away from our table. */
+    extern wifi_osi_funcs_t espradio_osi_funcs;
+    extern wifi_osi_funcs_t *g_osi_funcs_p;
+    extern wifi_osi_funcs_t g_wifi_osi_funcs;
+    extern wifi_osi_funcs_t *s_heap_osi_funcs;
+
+    /* If blob reset g_osi_funcs_p to &g_wifi_osi_funcs, redirect to heap copy. */
+    if (s_heap_osi_funcs) {
+        memcpy(s_heap_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+        memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+        g_osi_funcs_p = s_heap_osi_funcs;
+    }
+
+    /* Relocate pp_wdev_funcs from the heap (DMA-corruptible) to a static
+     * .bss buffer where DMA cannot reach. */
+    {
+        extern volatile uint32_t *pp_wdev_funcs;
+        if (pp_wdev_funcs) {
+            volatile uint32_t *heap_buf = pp_wdev_funcs;
+            for (int i = 0; i < PP_WDEV_FUNCS_ENTRIES; i++)
+                s_pp_wdev_save[i] = heap_buf[i];
+            pp_wdev_funcs = (volatile uint32_t *)s_pp_wdev_save;
+        }
+    }
+}
+
 #define ESPRADIO_NETIF_RXRING_SIZE  8
 #define ESPRADIO_NETIF_FRAME_MAX   1600
 

--- a/osi.c
+++ b/osi.c
@@ -13,34 +13,56 @@
 #define ESPRADIO_PHY_MODEM_WIFI 1u
 
 extern wifi_osi_funcs_t espradio_osi_funcs;
-extern int coex_pti_get(uint32_t event, uint8_t *pti);
 static void espradio_wifi_reset_mac(void);
 void espradio_timer_pending_reset(void);
 
 wifi_osi_funcs_t *g_osi_funcs_p;
 
+/* Declared in radio.c — heap-allocated OSI table placed far from BSS to avoid
+ * WiFi DMA corruption.  All runtime table updates go here AND to g_wifi_osi_funcs. */
+extern wifi_osi_funcs_t *s_heap_osi_funcs __attribute__((weak));
+
+static void espradio_sync_osi_tables(void) {
+    memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    if (s_heap_osi_funcs) {
+        memcpy(s_heap_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    }
+    /* NOTE: do NOT set g_osi_funcs_p here.  The blob's wifi_osi_funcs_register
+     * checks "g_osi_funcs_p != 0" at entry and returns immediately if it is
+     * already set, skipping critical blob-internal variable initialization.
+     * g_osi_funcs_p is set by the blob inside esp_wifi_init_internal(). */
+}
+
 void espradio_prepare_memory_for_wifi(void) {
-    g_osi_funcs_p = &espradio_osi_funcs;
+    espradio_sync_osi_tables();
 #if ESPRADIO_OSI_DEBUG
     printf("osi: prepare_memory_for_wifi (no-op wdev_last_desc_reset_ptr)\n");
 #endif
 }
 
 void espradio_ensure_osi_ptr(void) {
-    g_osi_funcs_p = &espradio_osi_funcs;
-    memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    espradio_sync_osi_tables();
 #if ESPRADIO_OSI_DEBUG
     printf("osi: ensure_osi_ptr\n");
 #endif
 }
 
+extern void espradio_post_start_cb(void);
+
 esp_err_t espradio_esp_wifi_start(void) {
 #if ESPRADIO_OSI_DEBUG
     printf("osi: esp_wifi_start (write table then call blob)\n");
 #endif
-    g_osi_funcs_p = &espradio_osi_funcs;
+    memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    if (s_heap_osi_funcs) {
+        memcpy(s_heap_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    }
     espradio_timer_pending_reset();
-    return esp_wifi_start();
+    esp_err_t rc = esp_wifi_start();
+    if (rc == ESP_OK) {
+        espradio_post_start_cb();
+    }
+    return rc;
 }
 
 /* Simple printf backend expected by libcoexist.a. */
@@ -141,32 +163,15 @@ static uint32_t espradio_queue_msg_waiting(void *queue) {
     return espradio_queue_len(queue);
 }
 
-static void *espradio_event_group_create(void) {
-    espradio_panic("todo: _event_group_create");
-}
-
-static void espradio_event_group_delete(void *event) {
-    espradio_panic("todo: _event_group_delete");
-}
-
-static uint32_t espradio_event_group_set_bits(void *event, uint32_t bits) {
-    espradio_panic("todo: _event_group_set_bits");
-}
-
-static uint32_t espradio_event_group_clear_bits(void *event, uint32_t bits) {
-    espradio_panic("todo: _event_group_clear_bits");
-}
-
-static uint32_t espradio_event_group_wait_bits(void *event, uint32_t bits_to_wait_for, int clear_on_exit, int wait_for_all_bits, uint32_t block_time_tick) {
-#if ESPRADIO_OSI_DEBUG
-    printf("osi: event_group_wait_bits ev=%p bits=0x%lx\n", (void *)event, (unsigned long)bits_to_wait_for);
-#endif
-    (void)event;
-    (void)clear_on_exit;
-    (void)wait_for_all_bits;
-    (void)block_time_tick;
-    return bits_to_wait_for;
-}
+/* Event group functions — implemented in Go (radio.go), declared here
+ * so the OSI table references the Go exports instead of stale C stubs. */
+void *espradio_event_group_create(void);
+void  espradio_event_group_delete(void *event);
+uint32_t espradio_event_group_set_bits(void *event, uint32_t bits);
+uint32_t espradio_event_group_clear_bits(void *event, uint32_t bits);
+uint32_t espradio_event_group_wait_bits(void *event, uint32_t bits_to_wait_for,
+                                        int clear_on_exit, int wait_for_all_bits,
+                                        uint32_t block_time_tick);
 
 void espradio_run_task(void *task_func, void *task_handle) {
 #if ESPRADIO_OSI_DEBUG
@@ -485,6 +490,19 @@ static void espradio_wifi_apb80m_request(void) {
 
 static void espradio_wifi_apb80m_release(void) {
 }
+
+/* The blob calls _wifi_clock_enable/_wifi_clock_disable asymmetrically
+ * (more disables than enables).  With a ref-counted implementation the
+ * ref count eventually underflows, powering down the WiFi domain while
+ * the radio is still active → pc:nil.  Rust esp-wifi discovered this
+ * and makes both callbacks no-ops; clocks are pre-enabled once at boot
+ * via espradio_hal_init_clocks_go() in Enable(). */
+static void espradio_wifi_clock_enable_noop(void) { }
+static void espradio_wifi_clock_disable_noop(void) { }
+
+/* Same issue for RTC isolation: the blob toggles ISO asymmetrically. */
+static void espradio_wifi_rtc_enable_iso_noop(void) { }
+static void espradio_wifi_rtc_disable_iso_noop(void) { }
 
 static void espradio_phy_disable(void) {
     phy_wifi_enable_set(0);
@@ -1076,25 +1094,90 @@ void vPortFree(void *p) {
 void * espradio_wifi_create_queue(int queue_len, int item_size);
 
 void espradio_wifi_delete_queue(void * queue);
-extern int coex_schm_flexible_period_set(uint8_t period);
-extern uint8_t coex_schm_flexible_period_get(void);
 
-static uint32_t espradio_coex_status_get(void) {
-    espradio_ensure_osi_ptr();
-    return coex_status_get(0);
-}
+/* -------------------------------------------------------------------------
+ * Coex stubs — WiFi-only, no Bluetooth coexistence needed.
+ *
+ * Many libcoexist.a functions (even those in flash) internally call ROM
+ * trampoline functions (coex_schm_lock, coex_schm_unlock, coex_core_request,
+ * etc.) whose implementation pointers in DRAM are never fully initialized.
+ * Calling any of them crashes with pc:nil.
+ *
+ * We replace ALL coex entries in the wifi_osi_funcs_t table with safe stubs
+ * that never touch libcoexist or ROM code.
+ * ----------------------------------------------------------------------- */
+
+static int espradio_coex_init(void) { return 0; }
+static void espradio_coex_deinit(void) {}
+static int espradio_coex_enable(void) { return 0; }
+static void espradio_coex_disable(void) {}
+
+static uint32_t espradio_coex_status_get(void) { return 0; }
 
 static void espradio_coex_condition_set(uint32_t type, bool dissatisfy) {
-    (void)type;
-    (void)dissatisfy;
+    (void)type; (void)dissatisfy;
+}
+
+static int espradio_coex_wifi_request(uint32_t event, uint32_t latency, uint32_t duration) {
+    (void)event; (void)latency; (void)duration;
+    return 0;
 }
 
 static int espradio_coex_wifi_release(uint32_t event) {
-    return coex_wifi_release(event);
+    (void)event; return 0;
 }
 
+static int espradio_coex_wifi_channel_set(uint8_t primary, uint8_t secondary) {
+    (void)primary; (void)secondary;
+    return 0;
+}
+
+static int espradio_coex_event_duration_get(uint32_t event, uint32_t *duration) {
+    (void)event;
+    if (duration) *duration = 0;
+    return 0;
+}
+
+static int espradio_coex_pti_get(uint32_t event, uint8_t *pti) {
+    (void)event;
+    if (pti) *pti = 0;
+    return 0;
+}
+
+static void espradio_coex_schm_status_bit_clear(uint32_t type, uint32_t status) {
+    (void)type; (void)status;
+}
+
+static void espradio_coex_schm_status_bit_set(uint32_t type, uint32_t status) {
+    (void)type; (void)status;
+}
+
+static int espradio_coex_schm_interval_set(uint32_t interval) {
+    (void)interval; return 0;
+}
+
+static uint32_t espradio_coex_schm_interval_get(void) { return 0; }
+static uint8_t espradio_coex_schm_curr_period_get(void) { return 0; }
+static void *espradio_coex_schm_curr_phase_get(void) { return NULL; }
+static int espradio_coex_schm_process_restart(void) { return 0; }
+
 static int espradio_coex_schm_register_cb(int type, int (*cb)(int)) {
-    return coex_schm_register_callback((coex_schm_callback_type_t)type, (void *)cb);
+    (void)type; (void)cb;
+    return 0;
+}
+
+static int espradio_coex_register_start_cb(int (*cb)(void)) {
+    (void)cb; return 0;
+}
+
+static int espradio_coex_schm_flexible_period_set(uint8_t period) {
+    (void)period; return 0;
+}
+
+static uint8_t espradio_coex_schm_flexible_period_get(void) { return 0; }
+
+static void *espradio_coex_schm_get_phase_by_idx(int idx) {
+    (void)idx; return NULL;
 }
 
 /* Coexistence adapter (esp_coexist_adapter.h) ********************************************/
@@ -1327,10 +1410,10 @@ wifi_osi_funcs_t espradio_osi_funcs = {
     ._timer_setfn = espradio_timer_setfn,
     ._timer_arm_us = espradio_timer_arm_us,
     ._wifi_reset_mac = espradio_wifi_reset_mac,
-    ._wifi_clock_enable = espradio_hal_init_clocks_go,
-    ._wifi_clock_disable = espradio_hal_disable_clocks_go,
-    ._wifi_rtc_enable_iso = espradio_hal_wifi_rtc_enable_iso_go,
-    ._wifi_rtc_disable_iso = espradio_hal_wifi_rtc_disable_iso_go,
+    ._wifi_clock_enable = espradio_wifi_clock_enable_noop,
+    ._wifi_clock_disable = espradio_wifi_clock_disable_noop,
+    ._wifi_rtc_enable_iso = espradio_wifi_rtc_enable_iso_noop,
+    ._wifi_rtc_disable_iso = espradio_wifi_rtc_disable_iso_noop,
     ._esp_timer_get_time = espradio_esp_timer_get_time,
     ._nvs_set_i8 = espradio_nvs_set_i8,
     ._nvs_get_i8 = espradio_nvs_get_i8,
@@ -1361,28 +1444,28 @@ wifi_osi_funcs_t espradio_osi_funcs = {
     ._wifi_zalloc = espradio_wifi_zalloc,
     ._wifi_create_queue = espradio_wifi_create_queue,
     ._wifi_delete_queue = espradio_wifi_delete_queue,
-    ._coex_init = coex_init,
-    ._coex_deinit = coex_deinit,
-    ._coex_enable = coex_enable,
-    ._coex_disable = coex_disable,
+    ._coex_init = espradio_coex_init,
+    ._coex_deinit = espradio_coex_deinit,
+    ._coex_enable = espradio_coex_enable,
+    ._coex_disable = espradio_coex_disable,
     ._coex_status_get = espradio_coex_status_get,
     ._coex_condition_set = espradio_coex_condition_set,
-    ._coex_wifi_request = coex_wifi_request,
+    ._coex_wifi_request = espradio_coex_wifi_request,
     ._coex_wifi_release = espradio_coex_wifi_release,
-    ._coex_wifi_channel_set = coex_wifi_channel_set,
-    ._coex_event_duration_get = coex_event_duration_get,
-    ._coex_pti_get = coex_pti_get,
-    ._coex_schm_status_bit_clear = coex_schm_status_bit_clear,
-    ._coex_schm_status_bit_set = coex_schm_status_bit_set,
-    ._coex_schm_interval_set = coex_schm_interval_set,
-    ._coex_schm_interval_get = coex_schm_interval_get,
-    ._coex_schm_curr_period_get = coex_schm_curr_period_get,
-    ._coex_schm_curr_phase_get = coex_schm_curr_phase_get,
-    ._coex_schm_process_restart = coex_schm_process_restart,
+    ._coex_wifi_channel_set = espradio_coex_wifi_channel_set,
+    ._coex_event_duration_get = espradio_coex_event_duration_get,
+    ._coex_pti_get = espradio_coex_pti_get,
+    ._coex_schm_status_bit_clear = espradio_coex_schm_status_bit_clear,
+    ._coex_schm_status_bit_set = espradio_coex_schm_status_bit_set,
+    ._coex_schm_interval_set = espradio_coex_schm_interval_set,
+    ._coex_schm_interval_get = espradio_coex_schm_interval_get,
+    ._coex_schm_curr_period_get = espradio_coex_schm_curr_period_get,
+    ._coex_schm_curr_phase_get = espradio_coex_schm_curr_phase_get,
+    ._coex_schm_process_restart = espradio_coex_schm_process_restart,
     ._coex_schm_register_cb = espradio_coex_schm_register_cb,
-    ._coex_register_start_cb = coex_register_start_cb,
-    ._coex_schm_flexible_period_set = coex_schm_flexible_period_set,
-    ._coex_schm_flexible_period_get = coex_schm_flexible_period_get,
-    ._coex_schm_get_phase_by_idx = coex_schm_get_phase_by_idx,
+    ._coex_register_start_cb = espradio_coex_register_start_cb,
+    ._coex_schm_flexible_period_set = espradio_coex_schm_flexible_period_set,
+    ._coex_schm_flexible_period_get = espradio_coex_schm_flexible_period_get,
+    ._coex_schm_get_phase_by_idx = espradio_coex_schm_get_phase_by_idx,
     ._magic = ESP_WIFI_OS_ADAPTER_MAGIC,
 };

--- a/radio.c
+++ b/radio.c
@@ -41,8 +41,12 @@ extern void *g_phyFuns;
 extern wifi_osi_funcs_t *g_osi_funcs_p;
 extern int rtc_get_reset_reason(int cpu_no);
 
-/* Stub for the WIFI_INIT_CONFIG_DEFAULT() macro; we actually use espradio_osi_funcs below */
+/* Stub for the WIFI_INIT_CONFIG_DEFAULT() macro; also kept filled as fallback. */
 wifi_osi_funcs_t g_wifi_osi_funcs = {0};
+
+/* Heap-allocated copy of the OSI table. Placed well away from BSS/DATA to avoid
+ * WiFi DMA corruption (PMP confirmed the zeroing bypasses the CPU). */
+wifi_osi_funcs_t *s_heap_osi_funcs;
 
 extern wifi_osi_funcs_t espradio_osi_funcs;
 
@@ -56,7 +60,7 @@ void espradio_set_blob_log_level(uint32_t level) {
 
 uint32_t espradio_wifi_boot_state(void) {
     uint32_t state = 0;
-    if (g_osi_funcs_p == &espradio_osi_funcs) {
+    if (g_osi_funcs_p == s_heap_osi_funcs || g_osi_funcs_p == &g_wifi_osi_funcs) {
         state |= 1u;
     }
     if (g_phyFuns != NULL) {
@@ -65,10 +69,11 @@ uint32_t espradio_wifi_boot_state(void) {
     return state;
 }
 
-const wpa_crypto_funcs_t g_wifi_default_wpa_crypto_funcs = {
-    .size = sizeof(wpa_crypto_funcs_t),
-    .version = ESP_WIFI_CRYPTO_VERSION,
-};
+/* g_wifi_default_wpa_crypto_funcs is provided by libwpa_supplicant.a
+ * (crypto_ops.c.obj) with real implementations of HMAC-SHA256, PBKDF2,
+ * AES-128, OMAC1, CCMP, AES-GMAC, SHA-256.  Do NOT define it here —
+ * overriding with a zeroed struct leaves the crypto function pointers
+ * NULL and crashes on WPA2 GTK rekey. */
 
 /* One-time ROM hook setup: route ets_printf/esp_rom_printf to UART
  * and install a global lock based on ROM interrupt lock/unlock.
@@ -120,27 +125,43 @@ esp_err_t espradio_wifi_init(void) {
               rtc_get_reset_reason(0), rtc_get_reset_reason(1));
     phy_get_romfunc_addr();
     RADIO_DBG("espradio: phy_get_romfunc_addr g_phyFuns=%p\n", g_phyFuns);
+
+    /* Allocate the OSI table on the heap, with 256-byte alignment and a
+     * 256-byte guard region on each side.  PMP analysis proved that the
+     * field-100 zeroing bypasses the CPU (WiFi DMA), so moving the table
+     * far from BSS prevents DMA descriptor mispointing from hitting it. */
+    {
+        size_t total = 256 + sizeof(wifi_osi_funcs_t) + 256;
+        uint8_t *raw = (uint8_t *)malloc(total);
+        if (!raw) return ESP_ERR_NO_MEM;
+        memset(raw, 0, total);
+        /* Align the table start to a 256-byte boundary within the allocation. */
+        uintptr_t table_addr = ((uintptr_t)raw + 256 + 255) & ~(uintptr_t)255;
+        s_heap_osi_funcs = (wifi_osi_funcs_t *)table_addr;
+        memcpy(s_heap_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    }
+
+    /* Populate g_wifi_osi_funcs as a backup; do NOT set g_osi_funcs_p yet.
+     * The blob's wifi_osi_funcs_register (called inside esp_wifi_init_internal)
+     * checks g_osi_funcs_p at entry and skips critical init if it's non-zero. */
+    memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    cfg.osi_funcs = &espradio_osi_funcs;
+    cfg.osi_funcs = s_heap_osi_funcs;
     cfg.nvs_enable = 0;
 
     extern wifi_osi_funcs_t *wifi_funcs;
-    wifi_funcs = &espradio_osi_funcs;
-    memcpy(&g_wifi_osi_funcs, &espradio_osi_funcs, sizeof(wifi_osi_funcs_t));
+    wifi_funcs = s_heap_osi_funcs;
 
-    esp_wifi_set_sleep_min_active_time(50000);
-    esp_wifi_set_keep_alive_time(10000000);
-    esp_wifi_set_sleep_wait_broadcast_data_time(15000);
     RADIO_DBG("espradio: before esp_wifi_bt_power_domain_on\n");
     esp_wifi_bt_power_domain_on();
     RADIO_DBG("espradio: after esp_wifi_bt_power_domain_on\n");
     espradio_bt_irq_prewire();
 
     extern void espradio_coex_adapter_init(void);
-    extern int coex_pre_init(void);
     espradio_coex_adapter_init();
-    int coex_rc = coex_pre_init();
-    RADIO_DBG("espradio: coex_pre_init -> %d\n", coex_rc);
+    extern esp_err_t coex_pre_init(void);
+    coex_pre_init();
 
     esp_err_t ret = esp_wifi_init_internal(&cfg);
     if (ret == 0) {

--- a/radio.go
+++ b/radio.go
@@ -102,6 +102,16 @@ func startSchedTicker() {
 }
 
 func schedOnce() {
+	// Poll the WiFi blob ISR to catch events where the hardware level
+	// stayed asserted but no new edge was generated.  This compensates
+	// for the edge-triggered interrupt mode losing events when the
+	// peripheral line never transitions low between assertions.
+	// Interrupts are disabled during the poll to prevent reentrant
+	// calls to the blob ISR from a real edge interrupt.
+	mask := interrupt.Disable()
+	C.espradio_call_wifi_isr()
+	interrupt.Restore(mask)
+
 	for C.espradio_isr_ring_tail() != C.espradio_isr_ring_head() {
 		idx := C.espradio_isr_ring_tail()
 		q := C.espradio_isr_ring_entry_queue(idx)
@@ -140,10 +150,12 @@ func Enable(config Config) error {
 	C.espradio_ensure_osi_ptr()
 
 	wifiISR = interrupt.New(1, func(interrupt.Interrupt) {
-		C.espradio_call_saved_isr(1)
+		C.espradio_call_wifi_isr()
 		kickSched()
 	})
 	wifiISR.Enable()
+
+	C.espradio_prewire_wifi_interrupts()
 
 	C.espradio_event_register_default_cb()
 	C.espradio_set_blob_log_level(C.uint32_t(config.Logging))
@@ -157,6 +169,7 @@ func Enable(config Config) error {
 		return makeError(errCode)
 	}
 	C.espradio_wifi_init_completed()
+	C.espradio_netif_init_netstack_cb()
 
 	return nil
 }
@@ -407,16 +420,10 @@ func safeGosched() {
 
 //export espradio_task_yield_go
 func espradio_task_yield_go() {
-	for i := 0; i < 4; i++ {
-		if C.espradio_timer_poll_due(8) == 0 {
-			break
-		}
-	}
-	for i := 0; i < 4; i++ {
-		if C.espradio_esp_timer_poll_due(8) == 0 {
-			break
-		}
-	}
+	// Don't fire timers inline here — the blob calls task_yield from
+	// deep call stacks and the extra depth risks overflowing the
+	// goroutine stack.  Timer polling is handled by schedOnce() in
+	// the ticker goroutine on its own stack.
 	kickSched()
 	runtime.Gosched()
 }
@@ -636,14 +643,18 @@ type eventGroup struct {
 	bits uint32
 }
 
-func newEventGroup() *eventGroup {
-	return &eventGroup{}
-}
+var eventGroups [8]eventGroup
+var eventGroupInUse [8]uint32
 
 //export espradio_event_group_create
 func espradio_event_group_create() unsafe.Pointer {
-	eg := newEventGroup()
-	return unsafe.Pointer(eg)
+	for i := range eventGroups {
+		if atomic.CompareAndSwapUint32(&eventGroupInUse[i], 0, 1) {
+			eventGroups[i].bits = 0
+			return unsafe.Pointer(&eventGroups[i])
+		}
+	}
+	panic("espradio: too many event groups")
 }
 
 //export espradio_event_group_delete
@@ -652,6 +663,12 @@ func espradio_event_group_delete(ptr unsafe.Pointer) {
 	eg.mu.Lock()
 	eg.bits = 0
 	eg.mu.Unlock()
+	for i := range eventGroups {
+		if eg == &eventGroups[i] {
+			atomic.StoreUint32(&eventGroupInUse[i], 0)
+			return
+		}
+	}
 }
 
 //export espradio_event_group_set_bits
@@ -720,9 +737,9 @@ type semaphore struct {
 }
 
 var (
-	semaphores      [4]semaphore
-	semaphoreIndex  uint32
-	wifiThreadSemMu sync.Mutex
+	semaphores        [4]semaphore
+	semaphoreIndex    uint32
+	wifiThreadSemMu   sync.Mutex
 	wifiThreadSemByTH = map[unsafe.Pointer]*semaphore{}
 	wifiThreadSemNil  semaphore
 )
@@ -872,12 +889,12 @@ func (q *queue) length() uint32 {
 }
 
 var (
-	wifiQueueObj      *queue
-	wifiQueuePtr      unsafe.Pointer
-	wifiQueueHandle   unsafe.Pointer
-	queueMapMu        sync.Mutex
-	queueByAlias      = map[unsafe.Pointer]*queue{}
-	queueByHandle     = map[unsafe.Pointer]*queue{}
+	wifiQueueObj    *queue
+	wifiQueuePtr    unsafe.Pointer
+	wifiQueueHandle unsafe.Pointer
+	queueMapMu      sync.Mutex
+	queueByAlias    = map[unsafe.Pointer]*queue{}
+	queueByHandle   = map[unsafe.Pointer]*queue{}
 )
 
 func registerQueue(handle unsafe.Pointer, alias unsafe.Pointer, q *queue) {


### PR DESCRIPTION
- Relocate pp_wdev_funcs from heap to .bss to prevent DMA corruption
- Patch NULL blob callback vars before they can be called
- Disable WiFi power save to avoid PM ROM dispatch crashes
- Allocate OSI table on heap with guard regions away from BSS
- Wire BT IRQs to stubs and improve ISR ring buffer handling
- Add WiFi disconnect reason codes to error strings

Fixes #6 