### PR TITLE
esp32c3: switch WiFi from polling to pure interrupt-driven handling

### DIFF
--- a/esp32c3/isr.c
+++ b/esp32c3/isr.c
@@ -28,9 +28,7 @@
  * our controlled init, and the blob's set_intr calls are no-ops. */
 void espradio_prewire_wifi_interrupts(void) {
     intr_matrix_set(0, ETS_WIFI_MAC_INTR_SOURCE, ESPRADIO_WIFI_CPU_INT);
-    intr_matrix_set(0, ETS_WIFI_MAC_NMI_SOURCE,  ESPRADIO_WIFI_CPU_INT);
     intr_matrix_set(0, ETS_WIFI_PWR_INTR_SOURCE, ESPRADIO_WIFI_CPU_INT);
-    intr_matrix_set(0, ETS_WIFI_BB_INTR_SOURCE,  ESPRADIO_WIFI_CPU_INT);
 }
 
 /* No-op: the blob calls set_intr to route peripheral sources to CPU
@@ -78,5 +76,28 @@ void espradio_wifi_int_to_level(void) {
     ESPRADIO_INTC_TYPE_REG   &= ~(1u << ESPRADIO_WIFI_CPU_INT);
     __asm__ volatile ("fence" ::: "memory");
     ESPRADIO_INTC_ENABLE_REG |=  (1u << ESPRADIO_WIFI_CPU_INT);
+}
+
+/* Raise WiFi CPU interrupt priority above the global threshold (5)
+ * so that hardware interrupts actually fire.  interrupt.Enable() sets
+ * priority to 5 which equals the threshold — not sufficient on ESP32-C3
+ * where the condition is priority > threshold. */
+void espradio_wifi_int_raise_priority(void) {
+    ESPRADIO_INTC_PRI_REG(ESPRADIO_WIFI_CPU_INT) = 6u;
+    __asm__ volatile ("fence" ::: "memory");
+}
+
+/* Called at the end of espradio_call_wifi_isr().  In level-triggered
+ * mode, mask CPU int 1 via the enable register to prevent re-entry
+ * if the hardware line is still asserted after the blob ISR ran.
+ * The bottom-half (schedOnce) unmasks after processing queued work. */
+void espradio_wifi_isr_post_mask(void) {
+    if ((ESPRADIO_INTC_TYPE_REG & (1u << ESPRADIO_WIFI_CPU_INT)) == 0) {
+        ESPRADIO_INTC_ENABLE_REG &= ~(1u << ESPRADIO_WIFI_CPU_INT);
+    }
+}
+
+void espradio_wifi_unmask(void) {
+    ESPRADIO_INTC_ENABLE_REG |= (1u << ESPRADIO_WIFI_CPU_INT);
 }
 

--- a/espradio.h
+++ b/espradio.h
@@ -20,6 +20,8 @@ void espradio_call_saved_isr(int32_t n);
 void espradio_call_wifi_isr(void);
 void espradio_prewire_wifi_interrupts(void);
 void espradio_wifi_int_to_level(void);
+void espradio_wifi_int_raise_priority(void);
+void espradio_wifi_unmask(void);
 void espradio_ints_on(uint32_t mask);
 void espradio_ints_off(uint32_t mask);
 int32_t espradio_queue_send(void *queue, void *item, uint32_t block_time_tick);

--- a/isr.c
+++ b/isr.c
@@ -34,6 +34,9 @@ void espradio_call_saved_isr(int32_t n) {
  * we call every non-NULL entry in the WiFi source range (0-3) so that
  * no registered handler is missed regardless of which index the blob
  * chose.  Called from the Go interrupt handler for CPU interrupt 1. */
+__attribute__((weak))
+void espradio_wifi_isr_post_mask(void) {}
+
 void espradio_call_wifi_isr(void) {
     s_in_isr = 1;
     __asm__ volatile ("fence" ::: "memory");
@@ -44,6 +47,7 @@ void espradio_call_wifi_isr(void) {
     }
     __asm__ volatile ("fence" ::: "memory");
     s_in_isr = 0;
+    espradio_wifi_isr_post_mask();
 }
 
 bool espradio_is_from_isr(void) {

--- a/radio.go
+++ b/radio.go
@@ -102,16 +102,6 @@ func startSchedTicker() {
 }
 
 func schedOnce() {
-	// Poll the WiFi blob ISR to catch events where the hardware level
-	// stayed asserted but no new edge was generated.  This compensates
-	// for the edge-triggered interrupt mode losing events when the
-	// peripheral line never transitions low between assertions.
-	// Interrupts are disabled during the poll to prevent reentrant
-	// calls to the blob ISR from a real edge interrupt.
-	mask := interrupt.Disable()
-	C.espradio_call_wifi_isr()
-	interrupt.Restore(mask)
-
 	for C.espradio_isr_ring_tail() != C.espradio_isr_ring_head() {
 		idx := C.espradio_isr_ring_tail()
 		q := C.espradio_isr_ring_entry_queue(idx)
@@ -133,6 +123,8 @@ func schedOnce() {
 			break
 		}
 	}
+
+	C.espradio_wifi_unmask()
 }
 
 func kickSched() {
@@ -154,6 +146,7 @@ func Enable(config Config) error {
 		kickSched()
 	})
 	wifiISR.Enable()
+	C.espradio_wifi_int_raise_priority()
 
 	C.espradio_prewire_wifi_interrupts()
 
@@ -169,6 +162,8 @@ func Enable(config Config) error {
 		return makeError(errCode)
 	}
 	C.espradio_wifi_init_completed()
+	C.espradio_wifi_int_to_level()
+	schedOnce()
 	C.espradio_netif_init_netstack_cb()
 
 	return nil


### PR DESCRIPTION
Fix three issues that prevented level-triggered WiFi interrupts from working:
1. Raise WiFi interrupt priority to 6 (was 5, equal to global threshold - never fired)
2. Route only MAC+PWR sources to CPU int 1 (unhandled NMI+BB kept line asserted)
3. Mask int 1 after blob ISR to prevent re-entry; unmask in schedOnce bottom-half