### PR TITLE
testing: add basic unit tests running with QEMU

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/tinygo-org/tinygo-dev
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install QEMU
+        run: apt-get update && apt-get install -y qemu-system-misc
+      - name: TinyGo version check
+        run: tinygo version
+      - name: Enforce Go Formatted Code
+        run: make fmt-check
+      - name: Run unit tests
+        run: |
+            go env -w GOFLAGS=-buildvcs=false
+            make unit-test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+fmt-check:
+	test -z "$(shell gofmt -l .)"
+
+unit-test:
+	tinygo test -target=esp32c3-qemu.json ./...
+
 update: update-esp-wifi
 	rm -rf blobs/headers
 	rm -rf blobs/include

--- a/esp32c3-qemu.json
+++ b/esp32c3-qemu.json
@@ -1,0 +1,4 @@
+{
+    "inherits": ["riscv-qemu"],
+    "build-tags": ["esp32c3_qemu_target"]
+}

--- a/examples/http-get/main.go
+++ b/examples/http-get/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ssid string
+	ssid     string
 	password string
 )
 
@@ -35,7 +35,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 
 	println("Connected. Getting URL...")
 	name := "John Doe"

--- a/examples/mqtt/main.go
+++ b/examples/mqtt/main.go
@@ -18,10 +18,10 @@ import (
 )
 
 var (
-	ssid   string
-	password   string
-	broker string = "test.mosquitto.org:1883"
-	topic  string = "cpu/freq"
+	ssid     string
+	password string
+	broker   string = "test.mosquitto.org:1883"
+	topic    string = "cpu/freq"
 )
 
 func main() {

--- a/netlink/debug.go
+++ b/netlink/debug.go
@@ -1,4 +1,5 @@
 //go:build netlinkdebug
+
 package netlink
 
 var debug = true

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"net"
 	"net/netip"
+	"runtime"
 	"sync"
 	"time"
-	"runtime"
 
 	"github.com/soypat/lneto/x/xnet"
 

--- a/netlink/netlink_test.go
+++ b/netlink/netlink_test.go
@@ -1,0 +1,53 @@
+package netlink
+
+import (
+	"testing"
+
+	nl "tinygo.org/x/drivers/netlink"
+)
+
+func TestNetConnectMissingSSID(t *testing.T) {
+	var e Esplink
+	err := e.NetConnect(&nl.ConnectParams{})
+	if err != nl.ErrMissingSSID {
+		t.Errorf("NetConnect with empty SSID = %v; want ErrMissingSSID", err)
+	}
+}
+
+func TestGetHostByNameEmpty(t *testing.T) {
+	var e Esplink
+	_, err := e.GetHostByName("")
+	if err == nil {
+		t.Error("GetHostByName(\"\") = nil error; want error")
+	}
+}
+
+func TestGetHostByNameIPv4(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"192.168.1.1", "192.168.1.1"},
+		{"10.0.0.1", "10.0.0.1"},
+		{"0.0.0.0", "0.0.0.0"},
+	}
+	var e Esplink
+	for _, tt := range tests {
+		got, err := e.GetHostByName(tt.input)
+		if err != nil {
+			t.Errorf("GetHostByName(%q) error = %v; want nil", tt.input, err)
+			continue
+		}
+		if got.String() != tt.want {
+			t.Errorf("GetHostByName(%q) = %v; want %v", tt.input, got.String(), tt.want)
+		}
+	}
+}
+
+func TestGetHostByNameInvalidIPv4(t *testing.T) {
+	var e Esplink
+	_, err := e.GetHostByName("999.999.999.999")
+	if err == nil {
+		t.Error("GetHostByName(\"999.999.999.999\") = nil error; want parse error")
+	}
+}

--- a/netlink/nodebug.go
+++ b/netlink/nodebug.go
@@ -1,4 +1,5 @@
 //go:build !netlinkdebug
+
 package netlink
 
 var debug = false

--- a/radio_esp32c3_qemu.go
+++ b/radio_esp32c3_qemu.go
@@ -1,0 +1,19 @@
+//go:build esp32c3_qemu_target
+
+package espradio
+
+/*
+#cgo CFLAGS: -Iblobs/include
+#cgo CFLAGS: -Iblobs/include/esp32c3
+#cgo CFLAGS: -Iblobs/include/local
+#cgo CFLAGS: -Iblobs/headers
+#cgo CFLAGS: -DCONFIG_SOC_WIFI_NAN_SUPPORT=0
+#cgo CFLAGS: -DESPRADIO_PHY_PATCH_ROMFUNCS=0
+*/
+import "C"
+
+// ticksPerSecond matches the real ESP32-C3 value used to convert timer ticks.
+const ticksPerSecond = 16_000_000
+
+// initHardware is a no-op for QEMU: no modem power / clock hardware present.
+func initHardware() error { return nil }

--- a/radio_test.go
+++ b/radio_test.go
@@ -1,0 +1,35 @@
+package espradio
+
+import (
+	"testing"
+)
+
+func TestLogLevelString(t *testing.T) {
+	tests := []struct {
+		level    LogLevel
+		expected string
+	}{
+		{LogLevelNone, "NONE"},
+		{LogLevelError, "ERROR"},
+		{LogLevelWarning, "WARN"},
+		{LogLevelInfo, "INFO"},
+		{LogLevelDebug, "DEBUG"},
+		{LogLevelVerbose, "VERBOSE"},
+		{LogLevel(99), "?"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.expected {
+			t.Errorf("LogLevel(%d).String() = %v; want %v", tt.level, got, tt.expected)
+		}
+	}
+}
+
+func TestBoolToInt(t *testing.T) {
+	if got := boolToInt(true); got != 1 {
+		t.Errorf("boolToInt(true) = %v; want 1", got)
+	}
+	if got := boolToInt(false); got != 0 {
+		t.Errorf("boolToInt(false) = %v; want 0", got)
+	}
+}


### PR DESCRIPTION
This PR is to add very basic unit tests running with the `tinygo test` command using QEMU emulation:

```
$ tinygo test -target=esp32c3-qemu.json ./...
ok      tinygo.org/x/espradio   0.056s
?       tinygo.org/x/espradio/examples/ap       [no test files]
?       tinygo.org/x/espradio/examples/connect-and-dhcp [no test files]
?       tinygo.org/x/espradio/examples/http-app [no test files]
?       tinygo.org/x/espradio/examples/http-get [no test files]
?       tinygo.org/x/espradio/examples/http-static      [no test files]
?       tinygo.org/x/espradio/examples/mqtt     [no test files]
?       tinygo.org/x/espradio/examples/scan     [no test files]
?       tinygo.org/x/espradio/examples/starting [no test files]
?       tinygo.org/x/espradio/examples/webserver        [no test files]
ok      tinygo.org/x/espradio/netlink   0.056s
```

Requires installing `qemu-system-riscv32` which is part of the `qemu-system-misc` package on Ubuntu:

```
sudo apt install qemu-system-misc
```

Requires https://github.com/tinygo-org/tinygo/pull/5273 to use.