### PR TITLE
arena: add ArenaStats() + configurable pool size, shrink S3 default to 48kb

### DIFF
--- a/arena.c
+++ b/arena.c
@@ -117,6 +117,8 @@ void *espradio_arena_alloc(size_t size) {
         blk = FREE_NEXT(blk);
     }
     ARENA_DBG("arena: alloc %zu FAILED (OOM)\n", size);
+    /* Use puts instead of printf to avoid printf→malloc recursion via --wrap */
+    puts("arena: OOM");
     return NULL;
 }
 
@@ -130,7 +132,25 @@ void *espradio_arena_calloc(size_t n, size_t size) {
 void espradio_arena_free(void *p) {
     if (!p) return;
     uint8_t *blk = PAYLOAD_BLK(p);
+
+    /* Reject pointers outside the arena pool.  With --wrap=free on
+     * Xtensa, ALL free() calls arrive here — including frees of
+     * non-arena memory (picolibc internals, ROM buffers, etc.).
+     * Without this check the coalescing code below would interpret
+     * random memory as block headers and corrupt the Go heap. */
+    if (blk < arena_base || blk >= arena_base + arena_cap) {
+        ARENA_DBG("arena: free %p OUTSIDE pool [%p, %p) — ignored\n",
+                  p, arena_base, arena_base + arena_cap);
+        return;
+    }
+
     size_t bsz = BLK_SIZE(blk);
+
+    /* Sanity-check the block header. */
+    if (bsz == 0 || bsz > arena_cap || blk + bsz > arena_base + arena_cap) {
+        ARENA_DBG("arena: free %p corrupt header (bsz=%zu) — ignored\n", p, bsz);
+        return;
+    }
 
     ARENA_DBG("arena: free %p (blk %p, size %zu)\n", p, blk, bsz);
 
@@ -170,7 +190,14 @@ void *espradio_arena_realloc(void *ptr, size_t new_size) {
     if (new_size == 0) { espradio_arena_free(ptr); return NULL; }
 
     uint8_t *blk = PAYLOAD_BLK(ptr);
+    /* Reject non-arena pointers (see espradio_arena_free comment). */
+    if (blk < arena_base || blk >= arena_base + arena_cap) {
+        return espradio_arena_alloc(new_size);
+    }
     size_t old_total = BLK_SIZE(blk);
+    if (old_total == 0 || old_total > arena_cap || blk + old_total > arena_base + arena_cap) {
+        return espradio_arena_alloc(new_size);
+    }
     size_t old_payload = old_total - OVERHEAD;
 
     void *np = espradio_arena_alloc(new_size);

--- a/espradio.h
+++ b/espradio.h
@@ -4,6 +4,7 @@
 
 /* ===== Go → C (implemented in top-level .c files) ===== */
 void espradio_arena_init(uint8_t *base, size_t cap);
+void espradio_arena_stats(uint32_t *used, uint32_t *capacity);
 void espradio_set_blob_log_level(uint32_t level);
 esp_err_t espradio_wifi_init(void);
 void espradio_wifi_init_completed(void);

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -24,6 +24,9 @@ type Esplink struct {
 	netstack  *espradio.Stack
 	berkeley  xnet.StackBerkeley
 	stackloop sync.Once
+
+	// ArenaPoolSize overrides the default arena pool size (bytes). Zero uses target default.
+	ArenaPoolSize int
 }
 
 func (n *Esplink) rstack() xnet.StackRetrying {
@@ -41,7 +44,8 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 	}
 
 	err := espradio.Enable(espradio.Config{
-		Logging: espradio.LogLevelError,
+		Logging:       espradio.LogLevelError,
+		ArenaPoolSize: n.ArenaPoolSize,
 	})
 	if err != nil {
 		if debug {

--- a/radio.go
+++ b/radio.go
@@ -55,6 +55,9 @@ func (l LogLevel) String() string {
 
 type Config struct {
 	Logging LogLevel
+	// ArenaPoolSize overrides the default per-target arena pool size (bytes).
+	// Zero means use the target default.
+	ArenaPoolSize int
 }
 
 type AccessPoint struct {
@@ -166,11 +169,22 @@ func kickSched() {
 // be collected.  One large pool kept alive by this global is safe.
 var arenaPool []byte
 
+// ArenaStats returns the current arena usage and capacity in bytes.
+func ArenaStats() (used, capacity uint32) {
+	var u, c C.uint32_t
+	C.espradio_arena_stats(&u, &c)
+	return uint32(u), uint32(c)
+}
+
 // Enable and configure the radio.
 func Enable(config Config) error {
 	// Allocate arena pool from Go heap and hand it to C.
-	arenaPool = make([]byte, arenaPoolSize)
-	C.espradio_arena_init((*C.uint8_t)(unsafe.Pointer(&arenaPool[0])), C.size_t(arenaPoolSize))
+	poolSize := arenaPoolSize
+	if config.ArenaPoolSize > 0 {
+		poolSize = config.ArenaPoolSize
+	}
+	arenaPool = make([]byte, poolSize)
+	C.espradio_arena_init((*C.uint8_t)(unsafe.Pointer(&arenaPool[0])), C.size_t(poolSize))
 
 	startSchedTicker()
 	time.Sleep(schedTickerMs * time.Millisecond)

--- a/radio_esp32s3.go
+++ b/radio_esp32s3.go
@@ -66,7 +66,7 @@ func initHardware() error {
 const ticksPerSecond = 16_000_000
 
 // S3 has 416KB SRAM1; larger arena pool for blob allocations.
-const arenaPoolSize = 80 * 1024
+const arenaPoolSize = 48 * 1024
 
 // ESP32-S3 (Xtensa): don't run the blob ISR from interrupt context — the deep
 // windowed call chains can overflow the interrupted goroutine's 8KB stack.


### PR DESCRIPTION
Add Go wrapper for espradio_arena_stats() and Config.ArenaPoolSize field to allow runtime measurement and override of the arena pool size. Thread ArenaPoolSize through Esplink for netlink users.

Measured peak arena usage across targets:
  ESP32-C3: ~29.4KB / 32KB (keep at 32KB, minimum viable)
  ESP32-S3: ~30.4KB / 80KB (shrink to 48KB, saves 32KB DRAM)