### PR TITLE
tests: add smoke tests to build examples against xiao-esp32c3 and xiao-esp32s3 targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,7 @@ jobs:
         run: |
             go env -w GOFLAGS=-buildvcs=false
             make unit-test
+      - name: Smoke test examples
+        run: |
+            go env -w GOFLAGS=-buildvcs=false
+            make smoke-test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ esp-wifi
 ./vscode
 *.bin
 *.elf
+build
+

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,15 @@ update: update-esp-wifi
 patch-esp32s3:
 	go run ./tools/patch_xtensa_literals.go blobs/libs/esp32s3/*.a
 
+smoke-test:
+	mkdir -p build
+	rm -rf build/*
+	@for example in ./examples/*/; do \
+		for target in xiao-esp32c3 xiao-esp32s3; do \
+			echo "tinygo build -target=$$target -size short -o build/$$(basename $$example) $$example"; \
+			tinygo build -target=$$target -size short -o build/$$(basename $$example) $$example || exit 1; \
+		done; \
+	done
+
 update-esp-wifi:
 	cd esp-wifi && git pull --rebase origin main


### PR DESCRIPTION
This PR adds smoke tests to build examples against xiao-esp32c3 and xiao-esp32s3 targets.