### PR TITLE
netlink: update to lneto BackoffStrategy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # espradio
 
-[![Build](https://github.com/tinygo-org/espradio/actions/workflows/build.yml/badge.svg)](https://github.com/tinygo-org/espradio/actions/workflows/build.yml)
+[![PkgGoDev](https://pkg.go.dev/badge/pkg.go.dev/tinygo.org/x/espradio)](https://pkg.go.dev/tinygo.org/x/espradio) [![Build](https://github.com/tinygo-org/espradio/actions/workflows/build.yml/badge.svg)](https://github.com/tinygo-org/espradio/actions/workflows/build.yml)
 
 TinyGo package for using the ESP32 onboard radio for wireless communication.
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,4 @@
+// Package espradio provides support for the ESP32-S2 and ESP32-S3 microcontrollers.
+// It is based on the ESP-IDF framework and provides access to Wi-Fi and Bluetooth.
+// The package is designed to be used with the TinyGo compiler.
+package espradio // import "tinygo.org/x/espradio"

--- a/espstack.go
+++ b/espstack.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"time"
 
+	"github.com/soypat/lneto"
 	"github.com/soypat/lneto/ethernet"
 	"github.com/soypat/lneto/x/xnet"
 )
@@ -110,8 +111,9 @@ func (stack *Stack) SetupWithDHCP(cfg DHCPConfig) (*xnet.DHCPResults, error) {
 	}
 
 	lstack := stack.LnetoStack()
-	const pollTime = 50 * time.Millisecond
-	rstack := lstack.StackRetrying(pollTime)
+	rstack := lstack.StackRetrying(lneto.BackoffStrategy(func(_ uint) time.Duration {
+		return 50 * time.Millisecond
+	}))
 
 	dhcpResults, err := rstack.DoDHCPv4(reqaddr, 3*time.Second, 3)
 	if err != nil {

--- a/examples/http-app/main-http.go
+++ b/examples/http-app/main-http.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/soypat/lneto"
 	"github.com/soypat/lneto/http/httpraw"
 	"github.com/soypat/lneto/tcp"
 	"github.com/soypat/lneto/x/xnet"
@@ -106,7 +107,9 @@ func main() {
 	println("got IP:", dhcp.AssignedAddr.String())
 
 	lstack := espstack.LnetoStack()
-	rstack := lstack.StackRetrying(pollTime)
+	rstack := lstack.StackRetrying(lneto.BackoffStrategy(func(_ uint) time.Duration {
+		return pollTime
+	}))
 	gatewayHW, err := rstack.DoResolveHardwareAddress6(dhcp.Router, 500*time.Millisecond, 4)
 	if err != nil {
 		panic("ARP resolve failed: " + err.Error())

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module tinygo.org/x/espradio
 go 1.24.4
 
 require (
-	github.com/soypat/lneto v0.0.0-20260411230216-9e4da57335e7
+	github.com/soypat/lneto v0.0.0-20260415000502-16c2c3de36a2
 	tinygo.org/x/drivers v0.34.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/soypat/lneto v0.0.0-20260411230216-9e4da57335e7 h1:eAHkhUeXPf7vCrsOAINeDt3lUUjZA0dJyd9jCxRSUlU=
-github.com/soypat/lneto v0.0.0-20260411230216-9e4da57335e7/go.mod h1:g/8Lk+hIsMZydyWDJjK2YfsCuG6jA5mWCO6U+4S7w1U=
+github.com/soypat/lneto v0.0.0-20260415000502-16c2c3de36a2 h1:eoExDNiTP/WWWyBH8UOKH7DG/j66ZAY8MLifUAQqULs=
+github.com/soypat/lneto v0.0.0-20260415000502-16c2c3de36a2/go.mod h1:g/8Lk+hIsMZydyWDJjK2YfsCuG6jA5mWCO6U+4S7w1U=
 github.com/soypat/natiu-mqtt v0.6.0 h1:ddrem9iAqFYtQOx2C7AhCizhPXXmGZs1T5fkvLroPO4=
 github.com/soypat/natiu-mqtt v0.6.0/go.mod h1:xEta+cwop9izVCW7xOx2W+ct9PRMqr0gNVkvBPnQTc4=
 tinygo.org/x/drivers v0.34.0 h1:lw8ePJeUSn9oICKBvQXHC9TIE+J00OfXfkGTrpXM9Iw=

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/soypat/lneto"
 	"github.com/soypat/lneto/x/xnet"
 
 	nl "tinygo.org/x/drivers/netlink"
@@ -15,6 +16,10 @@ import (
 )
 
 const pollTime = 5 * time.Millisecond
+
+var pollBackoff = lneto.BackoffStrategy(func(_ uint) time.Duration {
+	return pollTime
+})
 
 // Esplink implements the Netlinker interface for the ESP32-C3's WiFi interface, using the espradio package and an lneto Stack.
 type Esplink struct {
@@ -30,7 +35,7 @@ type Esplink struct {
 }
 
 func (n *Esplink) rstack() xnet.StackRetrying {
-	return n.netstack.LnetoStack().StackRetrying(pollTime)
+	return n.netstack.LnetoStack().StackRetrying(pollBackoff)
 }
 
 // NetConnect device to network
@@ -113,7 +118,7 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 	}
 	n.stackloop.Do(func() {
 		// Start stack goroutine once.
-		gostack := n.netstack.LnetoStack().StackGo(pollTime, xnet.StackGoConfig{
+		gostack := n.netstack.LnetoStack().StackGo(pollBackoff, xnet.StackGoConfig{
 			ListenerPoolConfig: xnet.TCPPoolConfig{
 				PoolSize:           2,
 				QueueSize:          4,


### PR DESCRIPTION
This PR updates to the latest lneto package.

`StackRetrying` and `StackGo` now take a `lneto.BackoffStrategy` function instead of a `time.Duration`. This adjusts for that change.

Tested on real hardware as well!