### PR TITLE
fix: add build tags to prevent errors when using go get

### DIFF
--- a/radio.go
+++ b/radio.go
@@ -1,3 +1,5 @@
+//go:build esp32c3 || esp32c3_qemu_target || esp32s3
+
 package espradio
 
 /*


### PR DESCRIPTION
This PR just adds build tags to prevent errors when using `go get` for installation on Go 1.26+