### PR TITLE
examples: add 'failure' message for improved output

### DIFF
--- a/examples/ap/main-ap.go
+++ b/examples/ap/main-ap.go
@@ -23,8 +23,7 @@ func main() {
 
 	println("ap: enabling radio...")
 	if err := espradio.Enable(espradio.Config{Logging: espradio.LogLevelError}); err != nil {
-		println("ap: enable err:", err)
-		return
+		failure("ap: enable err: " + err.Error())
 	}
 
 	println("ap: starting AP...")
@@ -35,15 +34,13 @@ func main() {
 		AuthOpen: true,
 	})
 	if err != nil {
-		println("ap: start err:", err)
-		return
+		failure("ap: start err: " + err.Error())
 	}
 
 	println("ap: starting L2 netdev (AP)...")
 	nd, err := espradio.StartNetDevAP()
 	if err != nil {
-		println("ap: netdev err:", err)
-		return
+		failure("ap: netdev err: " + err.Error())
 	}
 
 	const apIP = "192.168.4.1"
@@ -57,8 +54,7 @@ func main() {
 		MaxUDPPorts:   2,
 	})
 	if err != nil {
-		println("ap: stack err:", err)
-		return
+		failure("ap: stack err: " + err.Error())
 	}
 
 	println("ap: configuring DHCP server...")
@@ -68,14 +64,12 @@ func main() {
 		Subnet:     subnet,
 	})
 	if err != nil {
-		println("ap: dhcp server configure err:", err)
-		return
+		failure("ap: dhcp server configure err: " + err.Error())
 	}
 
 	err = stack.LnetoStack().RegisterUDP(&dhcpServer, nil, dhcpv4.DefaultClientPort)
 	if err != nil {
-		println("ap: dhcp server register err:", err)
-		return
+		failure("ap: dhcp server register err: " + err.Error())
 	}
 
 	println("ap: AP is running on", apIP, "- connect to", ssid)
@@ -98,5 +92,12 @@ func stackLoop(stack *espradio.Stack) {
 		}
 		_ = send
 		_ = recv
+	}
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/examples/connect-and-dhcp/main-dhcp.go
+++ b/examples/connect-and-dhcp/main-dhcp.go
@@ -21,15 +21,13 @@ func main() {
 		Logging: espradio.LogLevelError,
 	})
 	if err != nil {
-		println("could not enable radio:", err)
-		return
+		failure("could not enable radio: " + err.Error())
 	}
 
 	println("starting radio...")
 	err = espradio.Start()
 	if err != nil {
-		println("could not start radio:", err)
-		return
+		failure("could not start radio: " + err.Error())
 	}
 
 	println("connecting to", ssid, "...")
@@ -38,16 +36,14 @@ func main() {
 		Password: password,
 	})
 	if err != nil {
-		println("connect failed:", err)
-		return
+		failure("connect failed: " + err.Error())
 	}
 	println("connected to", ssid, "!")
 
 	println("starting L2 netdev...")
 	nd, err := espradio.StartNetDev()
 	if err != nil {
-		println("netdev failed:", err)
-		return
+		failure("netdev failed: " + err.Error())
 	}
 
 	println("creating lneto stack...")
@@ -57,8 +53,7 @@ func main() {
 		MaxTCPPorts: 1,
 	})
 	if err != nil {
-		println("stack failed:", err)
-		return
+		failure("stack failed: " + err.Error())
 	}
 
 	// Start the poll loop in the background.
@@ -68,8 +63,7 @@ func main() {
 	println("starting DHCP...")
 	dhcp, err := stack.SetupWithDHCP(espradio.DHCPConfig{})
 	if err != nil {
-		println("DHCP failed:", err)
-		return
+		failure("DHCP failed: " + err.Error())
 	}
 	println("got IP:", dhcp.AssignedAddr.String())
 	println("gateway:", dhcp.Router.String())
@@ -94,5 +88,12 @@ func stackLoop(stack *espradio.Stack) {
 		}
 		_ = send
 		_ = recv
+	}
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"log"
 	"net/http"
 	"time"
 
@@ -28,7 +27,7 @@ func main() {
 		Passphrase: password,
 	})
 	if err != nil {
-		log.Fatal(err)
+		failure("connect failed: " + err.Error())
 	}
 
 	println("Connected to WiFi.")
@@ -40,9 +39,8 @@ func main() {
 	host := h.String()
 	println("HTTP server listening on http://" + host + port)
 	err = http.ListenAndServe(host+port, nil)
-	for err != nil {
-		println("error:", err.Error())
-		time.Sleep(5 * time.Second)
+	if err != nil {
+		failure("HTTP server error: " + err.Error())
 	}
 }
 
@@ -50,4 +48,11 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	println(r.Method, r.URL.Path)
 	w.Header().Set(`Content-Type`, `text/plain; charset=UTF-8`)
 	io.WriteString(w, "hello")
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/http-app/main-http.go
+++ b/examples/http-app/main-http.go
@@ -56,15 +56,13 @@ func main() {
 		Logging: espradio.LogLevelError,
 	})
 	if err != nil {
-		println("could not enable radio:", err)
-		return
+		failure("could not enable radio: " + err.Error())
 	}
 
 	println("starting radio...")
 	err = espradio.Start()
 	if err != nil {
-		println("could not start radio:", err)
-		return
+		failure("could not start radio: " + err.Error())
 	}
 
 	println("connecting to", ssid, "...")
@@ -73,16 +71,14 @@ func main() {
 		Password: password,
 	})
 	if err != nil {
-		println("connect failed:", err)
-		return
+		failure("connect failed: " + err.Error())
 	}
 	println("connected to", ssid, "!")
 
 	println("starting L2 netdev...")
 	nd, err := espradio.StartNetDev()
 	if err != nil {
-		println("netdev failed:", err)
-		return
+		failure("netdev failed: " + err.Error())
 	}
 
 	println("creating lneto stack...")
@@ -92,8 +88,7 @@ func main() {
 		MaxTCPPorts: 1,
 	})
 	if err != nil {
-		println("stack failed:", err)
-		return
+		failure("stack failed: " + err.Error())
 	}
 
 	// Start the poll loop in the background.
@@ -101,8 +96,7 @@ func main() {
 	println("starting DHCP...")
 	dhcp, err := espstack.SetupWithDHCP(espradio.DHCPConfig{})
 	if err != nil {
-		println("DHCP failed:", err)
-		return
+		failure("DHCP failed: " + err.Error())
 	}
 	println("got IP:", dhcp.AssignedAddr.String())
 
@@ -112,7 +106,7 @@ func main() {
 	}))
 	gatewayHW, err := rstack.DoResolveHardwareAddress6(dhcp.Router, 500*time.Millisecond, 4)
 	if err != nil {
-		panic("ARP resolve failed: " + err.Error())
+		failure("ARP resolve failed: " + err.Error())
 	}
 	lstack.SetGateway6(gatewayHW)
 
@@ -141,18 +135,18 @@ func main() {
 		},
 	})
 	if err != nil {
-		panic("tcppool create: " + err.Error())
+		failure("tcppool create: " + err.Error())
 	}
 
 	listenAddr := netip.AddrPortFrom(dhcp.AssignedAddr, listenPort)
 	var listener tcp.Listener
 	err = listener.Reset(listenPort, tcpPool)
 	if err != nil {
-		panic("listener reset: " + err.Error())
+		failure("listener reset: " + err.Error())
 	}
 	err = lstack.RegisterListener(&listener)
 	if err != nil {
-		panic("listener register: " + err.Error())
+		failure("listener register: " + err.Error())
 	}
 
 	println("listening on", "http://"+listenAddr.String())
@@ -462,5 +456,12 @@ func loopForeverStack(stack *espradio.Stack) {
 		if send == 0 && recv == 0 {
 			time.Sleep(pollTime)
 		}
+	}
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/examples/http-get/main.go
+++ b/examples/http-get/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -33,7 +32,7 @@ func main() {
 		Passphrase: password,
 	})
 	if err != nil {
-		log.Fatal(err)
+		failure("WiFi connect failed: " + err.Error())
 	}
 
 	println("Connected. Getting URL...")
@@ -73,5 +72,12 @@ func main() {
 		cnt++
 		fmt.Printf("-------- %d --------\r\n", cnt)
 		time.Sleep(10 * time.Second)
+	}
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/examples/http-static/main-httpstatic.go
+++ b/examples/http-static/main-httpstatic.go
@@ -49,15 +49,13 @@ func main() {
 		Logging: espradio.LogLevelNone,
 	})
 	if err != nil {
-		println("could not enable radio:", err)
-		return
+		failure("could not enable radio: " + err.Error())
 	}
 
 	println("starting radio...")
 	err = espradio.Start()
 	if err != nil {
-		println("could not start radio:", err)
-		return
+		failure("could not start radio: " + err.Error())
 	}
 
 	println("connecting to", ssid, "...")
@@ -66,16 +64,14 @@ func main() {
 		Password: password,
 	})
 	if err != nil {
-		println("connect failed:", err)
-		return
+		failure("connect failed: " + err.Error())
 	}
 	println("connected to", ssid, "!")
 
 	println("starting L2 netdev...")
 	nd, err := espradio.StartNetDev()
 	if err != nil {
-		println("netdev failed:", err)
-		return
+		failure("netdev failed: " + err.Error())
 	}
 
 	println("creating lneto stack...")
@@ -85,8 +81,7 @@ func main() {
 		MaxTCPPorts: 1,
 	})
 	if err != nil {
-		println("stack failed:", err)
-		return
+		failure("stack failed: " + err.Error())
 	}
 
 	// Start the poll loop in the background.
@@ -95,7 +90,7 @@ func main() {
 
 	dhcpResults, err := espstack.SetupWithDHCP(espradio.DHCPConfig{})
 	if err != nil {
-		panic("DHCP failed:" + err.Error())
+		failure("DHCP failed: " + err.Error())
 	}
 	tcpPool, err := xnet.NewTCPPool(xnet.TCPPoolConfig{
 		PoolSize:           maxConns,
@@ -112,7 +107,7 @@ func main() {
 		},
 	})
 	if err != nil {
-		panic("tcppool create:" + err.Error())
+		failure("tcppool create: " + err.Error())
 	}
 
 	lstack := espstack.LnetoStack()
@@ -122,11 +117,11 @@ func main() {
 	var listener tcp.Listener
 	err = listener.Reset(listenPort, tcpPool)
 	if err != nil {
-		panic("listener reset:" + err.Error())
+		failure("listener reset: " + err.Error())
 	}
 	err = lstack.RegisterListener(&listener)
 	if err != nil {
-		panic("listener register:" + err.Error())
+		failure("listener register: " + err.Error())
 	}
 	println("listening on", "http://"+listenAddr.String())
 
@@ -241,5 +236,12 @@ func loopForeverStack(stack *espradio.Stack) {
 		if send == 0 && recv == 0 {
 			time.Sleep(pollTime)
 		}
+	}
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/examples/mqtt/main.go
+++ b/examples/mqtt/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net"
 	"time"
@@ -27,7 +26,7 @@ func main() {
 	time.Sleep(3 * time.Second)
 
 	if err := connectToWifi(); err != nil {
-		log.Fatal(err)
+		failure("WiFi connect failed: " + err.Error())
 	}
 
 	clientId := "tinygo-client-" + randomString(10)
@@ -48,7 +47,7 @@ func main() {
 		break
 	}
 	if conn == nil {
-		log.Fatal("all TCP connection attempts failed")
+		failure("all TCP connection attempts failed")
 	}
 	fmt.Printf("TCP connected to %v\n", conn.RemoteAddr())
 	defer conn.Close()
@@ -71,7 +70,7 @@ func main() {
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	err := client.Connect(ctx, conn, &varconn)
 	if err != nil {
-		log.Fatal("failed to connect: ", err)
+		failure("failed to connect: " + err.Error())
 	}
 	fmt.Println("MQTT CONNECT succeeded")
 
@@ -84,7 +83,7 @@ func main() {
 		},
 	})
 	if err != nil {
-		log.Fatal("failed to subscribe to", topic, err)
+		failure("failed to subscribe to " + topic + ": " + err.Error())
 	}
 	fmt.Printf("Subscribed to topic %s\n", topic)
 
@@ -96,7 +95,7 @@ func main() {
 
 	for i := 0; i < 10; i++ {
 		if !client.IsConnected() {
-			log.Fatal("client disconnected: ", client.Err())
+			failure("client disconnected: " + client.Err().Error())
 		}
 
 		payload := fmt.Sprintf("Random value: %d", randomInt(0, 100))
@@ -104,7 +103,7 @@ func main() {
 		pubVar.PacketIdentifier++
 		err = client.PublishPayload(pubFlags, pubVar, []byte(payload))
 		if err != nil {
-			log.Fatal("error transmitting message: ", err)
+			failure("error transmitting message: " + err.Error())
 		}
 
 		time.Sleep(time.Second)
@@ -112,7 +111,7 @@ func main() {
 		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		err = client.HandleNext()
 		if err != nil {
-			log.Fatal("handle next: ", err)
+			failure("handle next: " + err.Error())
 		}
 
 	}
@@ -158,4 +157,11 @@ func connectToWifi() error {
 	}
 
 	return errors.New("failed to connect to WiFi after 3 attempts")
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
+	}
 }

--- a/examples/webserver/webserver.go
+++ b/examples/webserver/webserver.go
@@ -7,7 +7,6 @@ package main
 import (
 	_ "embed"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -62,7 +61,7 @@ func main() {
 		Passphrase: password,
 	})
 	if err != nil {
-		log.Fatal(err)
+		failure("could not connect to WiFi: " + err.Error())
 	}
 
 	http.Handle("/", logRequest(root))
@@ -76,9 +75,8 @@ func main() {
 	host := h.String()
 	println("HTTP server listening on http://" + host + port)
 	err = http.ListenAndServe(host+port, nil)
-	for err != nil {
-		println("error:", err.Error())
-		time.Sleep(5 * time.Second)
+	if err != nil {
+		failure("http.ListenAndServe: " + err.Error())
 	}
 }
 
@@ -157,4 +155,11 @@ func cnt(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, `{"cnt": `)
 	io.WriteString(w, strconv.Itoa(counter))
 	io.WriteString(w, `}`)
+}
+
+func failure(msg string) {
+	for {
+		println("failure:", msg)
+		time.Sleep(1 * time.Second)
+	}
 }


### PR DESCRIPTION
This PR adds a 'failure' message for improved output to all examples.