### PR TITLE
MAC Learning and ARP revamp update for lneto

### DIFF
--- a/espstack.go
+++ b/espstack.go
@@ -22,10 +22,11 @@ type StackConfig struct {
 	StaticAddress netip.Addr
 	DNSServer     netip.Addr
 	NTPServer     netip.Addr
+	RandSeed      int64
 	Hostname      string
 	MaxTCPPorts   int
 	MaxUDPPorts   int
-	RandSeed      int64
+	PassivePeers  int
 }
 
 // DHCPConfig configures DHCP address acquisition.
@@ -56,6 +57,7 @@ func NewStack(dev *NetDev, cfg StackConfig) (*Stack, error) {
 		RandSeed:          time.Now().UnixNano() ^ cfg.RandSeed,
 		HardwareAddress:   mac,
 		MTU:               MTU,
+		PassivePeers:      cfg.PassivePeers,
 	})
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 require github.com/soypat/natiu-mqtt v0.6.0
+
+replace github.com/soypat/lneto => ../lneto

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,8 @@ module tinygo.org/x/espradio
 go 1.24.4
 
 require (
-	github.com/soypat/lneto v0.1.0
+	github.com/soypat/lneto v0.1.1-0.20260425023453-aa77403a2b32
 	tinygo.org/x/drivers v0.35.0
 )
 
 require github.com/soypat/natiu-mqtt v0.6.0
-
-replace github.com/soypat/lneto => ../lneto

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/soypat/lneto v0.1.0 h1:VAHCJ33hvC3wDqhM0Vm7w0k6vwNsOCAsQ8XTrXJpS7I=
-github.com/soypat/lneto v0.1.0/go.mod h1:g/8Lk+hIsMZydyWDJjK2YfsCuG6jA5mWCO6U+4S7w1U=
+github.com/soypat/lneto v0.1.1-0.20260425023453-aa77403a2b32 h1:4fNa4mcNPVTMJ3Kzn+cS/LqmpXhKM9SiZ9Vgu/Ucq3c=
+github.com/soypat/lneto v0.1.1-0.20260425023453-aa77403a2b32/go.mod h1:Be5PjwoYukvHFiUXxpYi8+ppH2F/gw/vjGBvFdv+Ti8=
 github.com/soypat/natiu-mqtt v0.6.0 h1:ddrem9iAqFYtQOx2C7AhCizhPXXmGZs1T5fkvLroPO4=
 github.com/soypat/natiu-mqtt v0.6.0/go.mod h1:xEta+cwop9izVCW7xOx2W+ct9PRMqr0gNVkvBPnQTc4=
 tinygo.org/x/drivers v0.35.0 h1:cTK36tsI/S4Mg3hCPH0MBjV/ta7XKQ+wpvch4mVqgsE=

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -95,9 +95,10 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 	}
 
 	espstack, err := espradio.NewStack(nd, espradio.StackConfig{
-		Hostname:    params.Ssid,
-		MaxUDPPorts: 2,
-		MaxTCPPorts: 1,
+		Hostname:     params.Ssid,
+		MaxUDPPorts:  2,
+		MaxTCPPorts:  1,
+		PassivePeers: 3,
 	})
 	if err != nil {
 		if debug {


### PR DESCRIPTION
Need to clone lneto locally next to espradio repository for this to work:

```
git clone espradio
git clone lneto
cd lneto
git switch arp-cache
cd ../espradio
git switch mac-learning
tinygo flash -monitor -target=xiao-esp32c3 -tags=pcapdebug -ldflags="-X main.ssid=Patoniato -X main.password=XXX" ./examples/webserver
```