### PR TITLE
netlink: allow setting hostname from netlink params

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.4
 
 require (
 	github.com/soypat/lneto v0.1.1-0.20260527165357-24d5d303bcb8
-	tinygo.org/x/drivers v0.35.0
+	tinygo.org/x/drivers v0.35.1-0.20260604174950-1d695a231aef
 )
 
 require github.com/soypat/natiu-mqtt v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/soypat/lneto v0.1.1-0.20260527165357-24d5d303bcb8 h1:w0XI6cvLwkR+7FQa
 github.com/soypat/lneto v0.1.1-0.20260527165357-24d5d303bcb8/go.mod h1:Be5PjwoYukvHFiUXxpYi8+ppH2F/gw/vjGBvFdv+Ti8=
 github.com/soypat/natiu-mqtt v0.6.0 h1:ddrem9iAqFYtQOx2C7AhCizhPXXmGZs1T5fkvLroPO4=
 github.com/soypat/natiu-mqtt v0.6.0/go.mod h1:xEta+cwop9izVCW7xOx2W+ct9PRMqr0gNVkvBPnQTc4=
-tinygo.org/x/drivers v0.35.0 h1:cTK36tsI/S4Mg3hCPH0MBjV/ta7XKQ+wpvch4mVqgsE=
-tinygo.org/x/drivers v0.35.0/go.mod h1:DQgKyHkB4G6IEOKVTAjApbKnWGwESN91EVJO+nMOE9Y=
+tinygo.org/x/drivers v0.35.1-0.20260604174950-1d695a231aef h1:nG/qd6hSQonHse2l8DYUrCuJSiCfcFD9n8YMze8sVo0=
+tinygo.org/x/drivers v0.35.1-0.20260604174950-1d695a231aef/go.mod h1:DQgKyHkB4G6IEOKVTAjApbKnWGwESN91EVJO+nMOE9Y=

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -13,6 +13,8 @@ import (
 	"tinygo.org/x/espradio"
 )
 
+const defaultHostname = "tinygo-espradio"
+
 const pollTime = 5 * time.Millisecond
 
 var pollBackoff = lneto.BackoffStrategy(func(_ uint) time.Duration {
@@ -93,8 +95,11 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 		return err
 	}
 
+	if len(params.Hostname) == 0 {
+		params.Hostname = defaultHostname
+	}
 	espstack, err := espradio.NewStack(nd, espradio.StackConfig{
-		Hostname:     params.Ssid,
+		Hostname:     params.Hostname,
 		MaxUDPPorts:  2,
 		MaxTCPPorts:  1,
 		PassivePeers: 255,


### PR DESCRIPTION
This allow the user to set the hostname for a device by using the Hostname netlink param. It also sets a more sensible default value than the Ssid name.

Addresses #29 