### PR TITLE
esp32: fix WiFi bring-up sequence, add link-state events and Reconnect

### DIFF
--- a/error.go
+++ b/error.go
@@ -68,6 +68,8 @@ func (e Error) Error() string {
 			return "espradio: timeout"
 		case 2:
 			return "espradio: auth expired"
+		case 4:
+			return "espradio: disassociated due to inactivity"
 		case 15:
 			return "espradio: 4-way handshake timeout"
 		case 201:

--- a/esp32/esp32.go
+++ b/esp32/esp32.go
@@ -10,6 +10,9 @@ package esp32
 // #cgo CFLAGS: -DCONFIG_SOC_WIFI_NAN_SUPPORT=0
 // #cgo CFLAGS: -DESPRADIO_PHY_PATCH_ROMFUNCS=0
 // #cgo CFLAGS: -fno-short-enums
+//
+// #include <stdint.h>
+// extern void ets_delay_us(uint32_t us);
 import "C"
 
 import (
@@ -17,6 +20,16 @@ import (
 	"sync/atomic"
 	"unsafe"
 )
+
+// modemResetMask matches MODEM_RESET_FIELD_WHEN_PU in esp-idf's
+// components/soc/esp32/register/soc/dport_reg.h:1082-1086 — DPORT_WIFIBB_RST
+// (bit0) | DPORT_WIFIMAC_RST (bit2) | DPORT_BTBB_RST (bit3) |
+// DPORT_BTMAC_RST (bit4) | DPORT_RW_BTMAC_RST (bit9). Pulsed on
+// DPORT.CORE_RST_EN by the real esp_wifi_bt_power_domain_on() — contrary to
+// a previous comment here, classic ESP32 DOES have a WiFi MAC reset bit;
+// only the newer PCR/MODEM_SYSCON-based chips (checked earlier this session
+// for ESP32-C6) lack a software-controlled reset for it.
+const modemResetMask = 1<<0 | 1<<2 | 1<<3 | 1<<4 | 1<<9
 
 var halWiFiClockRefcnt atomic.Uint32
 
@@ -26,13 +39,22 @@ func espradio_hal_init_clocks_go() {
 		return
 	}
 
-	// esp-hal init_clocks() for ESP32 simply enables all WiFi/BT clock gates.
-	// It deliberately does NOT touch DIG_PWC/DIG_ISO or pulse any peripheral
-	// reset — the ROM bootloader has already powered up the WiFi domain, and
-	// there is no WiFi MAC reset bit in DPORT.CORE_RST_EN (IDF's reset mask
-	// for the WiFi module is 0).
-	// See esp-radio/src/radio_clocks/clocks_ll/esp32.rs init_clocks().
+	// Full esp_wifi_bt_power_domain_on() sequence for classic ESP32
+	// (components/esp_phy/src/phy_init.c:427-452 — SOC_PM_MODEM_PD_BY_SW=1
+	// here, components/soc/esp32/include/soc/soc_caps.h:357, so unlike
+	// ESP32-C6 this is NOT a no-op on this chip): release WIFI_FORCE_PD,
+	// wait 10us for the domain to power up, enable the WiFi/BT common
+	// clock, pulse the modem reset, then release WIFI_FORCE_ISO. The
+	// previous version of this function only did the clock-enable step —
+	// harmless on a cold boot (the ROM bootloader already leaves
+	// FORCE_PD/FORCE_ISO cleared), but wrong after any path that sets them
+	// (e.g. resuming from a power-down sleep state).
+	esp.RTC_CNTL.SetDIG_PWC_WIFI_FORCE_PD(0)
+	C.ets_delay_us(10)
 	esp.DPORT.SetWIFI_CLK_EN(0xFFFFFFFF)
+	esp.DPORT.CORE_RST_EN.SetBits(modemResetMask)
+	esp.DPORT.CORE_RST_EN.ClearBits(modemResetMask)
+	esp.RTC_CNTL.DIG_ISO.ClearBits(1 << 28) // WIFI_FORCE_ISO
 }
 
 //export espradio_hal_disable_clocks_go
@@ -49,6 +71,12 @@ func espradio_hal_disable_clocks_go() {
 			break
 		}
 	}
+
+	// Mirrors esp_wifi_bt_power_domain_off(): re-assert FORCE_ISO and
+	// FORCE_PD (components/esp_phy/src/phy_init.c:455-467), in addition to
+	// the existing clock disable.
+	esp.RTC_CNTL.DIG_ISO.SetBits(1 << 28) // WIFI_FORCE_ISO
+	esp.RTC_CNTL.SetDIG_PWC_WIFI_FORCE_PD(1)
 
 	// Disable WiFi clocks (DPORT_WIFI_CLK_WIFI_EN_M = 0x406).
 	cur := esp.DPORT.GetWIFI_CLK_EN()
@@ -67,10 +95,14 @@ func espradio_hal_wifi_rtc_disable_iso_go() {
 
 //export espradio_hal_reset_wifi_mac_go
 func espradio_hal_reset_wifi_mac_go() {
-	// On ESP32 there is no WiFi MAC reset bit in DPORT.CORE_RST_EN (IDF's
-	// periph reset mask for the WiFi module is 0), so this is a no-op.
-	// Pulsing an arbitrary CORE_RST_EN bit would reset an unrelated
-	// peripheral and hang the WiFi bring-up.
+	// Deliberately still a no-op, but not for the reason the previous
+	// comment gave: classic ESP32 DOES have a WiFi MAC reset bit
+	// (DPORT_WIFIMAC_RST) — see modemResetMask above — and esp-idf's real
+	// esp_wifi_bt_power_domain_on() does pulse it. That pulse now happens
+	// in espradio_hal_init_clocks_go, in the same place and order as the
+	// real esp-idf sequence; duplicating it here (this hook is called
+	// separately by the blob's own OSI "_reset_mac" callback) would just
+	// re-reset the MAC a second time for no benefit.
 }
 
 //export espradio_hal_read_mac_go
@@ -79,19 +111,25 @@ func espradio_hal_read_mac_go(mac *C.uchar, iftype C.uint) C.int {
 		return -1
 	}
 
-	// ESP32 MAC address is in EFUSE BLK0:
-	//   BLK0_RDATA1: MAC[31:0] (bytes 5..2 in big-endian order)
-	//   BLK0_RDATA2: MAC[47:32] in lower 16 bits (bytes 1..0)
+	// components/hal/efuse_hal.c efuse_hal_get_mac() (chip-generic, used by
+	// esp32 via components/hal/esp32/include/hal/efuse_ll.h's
+	// efuse_ll_get_mac0/1() reading EFUSE.blk0_rdata1.rd_mac /
+	// blk0_rdata2.rd_mac_1) does a plain little-endian store, NOT the
+	// byte-reversed packing this port previously used (that reversed
+	// version was also found and fixed on ESP32-C3/C6 this session — same
+	// class of bug, copied across ports instead of derived from esp-idf):
+	//   *(uint32_t*)&mac[0] = efuse_ll_get_mac0();  // mac[0..3] = w0 LE
+	//   *(uint16_t*)&mac[4] = (uint16_t)efuse_ll_get_mac1(); // mac[4..5] = w1 LE
 	w0 := esp.EFUSE.BLK0_RDATA1.Get()
 	w1 := esp.EFUSE.BLK0_RDATA2.Get()
 
 	m := (*[6]byte)(unsafe.Pointer(mac))
-	m[0] = byte((w1 >> 8) & 0xff)
-	m[1] = byte(w1 & 0xff)
-	m[2] = byte((w0 >> 24) & 0xff)
-	m[3] = byte((w0 >> 16) & 0xff)
-	m[4] = byte((w0 >> 8) & 0xff)
-	m[5] = byte(w0 & 0xff)
+	m[0] = byte(w0 & 0xff)
+	m[1] = byte((w0 >> 8) & 0xff)
+	m[2] = byte((w0 >> 16) & 0xff)
+	m[3] = byte((w0 >> 24) & 0xff)
+	m[4] = byte(w1 & 0xff)
+	m[5] = byte((w1 >> 8) & 0xff)
 
 	if iftype != 0 {
 		m[0] |= 0x02

--- a/esp32/esp_phy_adapter.c
+++ b/esp32/esp_phy_adapter.c
@@ -156,9 +156,17 @@ static esp_phy_ant_config_t s_phy_ant_config_local = {
     .enabled_ant1 = 1,
 };
 
-/* Static PHY init data blob (128 bytes for ESP32).
- * Values from esp-hal PHY_INIT_DATA_DEFAULT for ESP32.
- * Different from ESP32-S3/C3 — uses different calibration constants.
+/* Static PHY init data blob (128 bytes for ESP32). Verified byte-for-byte
+ * against esp-idf's components/esp_phy/esp32/phy_init_data.c: the first
+ * 44 entries and the tail (indices 50-127) are literal constants there;
+ * indices 44-49 (TX power) are LIMIT(CONFIG_ESP_PHY_MAX_TX_POWER * 4, lo, hi)
+ * with CONFIG_ESP_PHY_MAX_TX_POWER defaulting to 20 (esp_phy/Kconfig), so
+ * val=80 clamps to each entry's hi bound: 78,72,66,60,56,52. Indices
+ * 107-127 aren't listed in esp-idf's initializer at all — C zero-fills the
+ * rest of a partially-initialized array, so they're 0x00 here too.
+ * The Rust esp-wifi-sys crate vendored under esp-wifi/ has no independent
+ * copy of this table; it links against this same esp-idf source.
+ * Different from ESP32-S3/C3 — those use different calibration constants.
  */
 static const esp_phy_init_data_t phy_init_data = { .params = {
     0x03, 0x03, 0x05, 0x09, 0x06, 0x05, 0x03, 0x06,   /*   0 -   7 */
@@ -166,7 +174,7 @@ static const esp_phy_init_data_t phy_init_data = { .params = {
     0x00, 0x05, 0x09, 0x06, 0x05, 0x03, 0x06, 0x05,   /*  16 -  23 */
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   /*  24 -  31 */
     0xfc, 0xfc, 0xfe, 0xf0, 0xf0, 0xf0, 0xe0, 0xe0,   /*  32 -  39 */
-    0xe0, 0x18, 0x18, 0x18, 0x50, 0x48, 0x42, 0x3c,   /*  40 -  47: TX power */
+    0xe0, 0x18, 0x18, 0x18, 0x4e, 0x48, 0x42, 0x3c,   /*  40 -  47: TX power */
     0x38, 0x34, 0x00, 0x01, 0x01, 0x02, 0x02, 0x03,   /*  48 -  55 */
     0x04, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   /*  56 -  63 */
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   /*  64 -  71 */

--- a/examples/http-get/main.go
+++ b/examples/http-get/main.go
@@ -28,8 +28,13 @@ func main() {
 
 	println("Connecting to WiFi...")
 	err := link.NetConnect(&nl.ConnectParams{
-		Ssid:       ssid,
-		Passphrase: password,
+		Ssid:            ssid,
+		Passphrase:      password,
+		ConnectTimeout:  time.Minute,
+		Retries:         5,
+		ConnectMode:     nl.ConnectModeSTA,
+		AuthType:        nl.AuthTypeWPA2Mixed,
+		WatchdogTimeout: time.Minute,
 	})
 	if err != nil {
 		failure("WiFi connect failed: " + err.Error())

--- a/netif.c
+++ b/netif.c
@@ -52,7 +52,17 @@ extern void *g_phyFuns;
  * may be in an inconsistent state under cooperative scheduling (the blob
  * expects ppTask to run preemptively and finalise frame descriptors before
  * PM callbacks access them).  With WIFI_PS_NONE the return value is
- * irrelevant — wrap it to always return 0 ("idle") and avoid the crash. */
+ * irrelevant — wrap it to always return 0 ("idle") and avoid the crash.
+ *
+ * A matching __wrap_ppCheckIsConnTraffic was tried alongside re-enabling
+ * WIFI_PS_MIN_MODEM after a successful connect, but that combination
+ * produced consistent "auth expired" connect failures on real hardware
+ * even after power save was also forced off (WIFI_PS_NONE) for the whole
+ * duration of the probe/auth/assoc handshake — i.e. neither the timing of
+ * the switch nor the wrap's correctness could be confirmed as the actual
+ * fix. Reverted both (this wrap and the WIFI_PS_MIN_MODEM re-enable in
+ * radio.go) back to the known-working baseline — power save permanently
+ * off — pending isolating the real cause on real hardware. */
 int __wrap_ppCheckTxConnTrafficIdle(void) { return 0; }
 
 /* ROM-fixed pointer variables in the 0x3fcef9xx region that are critical for

--- a/netlink/errors.go
+++ b/netlink/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	errInvalidIPAddress = errors.New("invalid IP address")
 	errEmptyHostname    = errors.New("empty hostname")
+	errNotConnected     = errors.New("not connected")
 )

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -25,6 +25,15 @@ var pollBackoff = lneto.BackoffStrategy(func(_ uint) time.Duration {
 type Esplink struct {
 	params   *nl.ConnectParams
 	notifyCb func(nl.Event)
+	cbMu     sync.Mutex
+
+	ssid     string
+	password string
+
+	eventCh      chan espradio.ConnEvent
+	eventOnce    sync.Once
+	lastReason   uint8
+	lastReasonMu sync.Mutex
 
 	netstack  *espradio.Stack
 	gostack   xnet.StackGo
@@ -44,6 +53,10 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 	if len(params.Ssid) == 0 {
 		return nl.ErrMissingSSID
 	}
+
+	n.ssid = params.Ssid
+	n.password = params.Passphrase
+	n.wireConnectEvents()
 
 	if debug {
 		println("Esplink NetConnect: ssid:", params.Ssid)
@@ -114,8 +127,11 @@ func (n *Esplink) NetConnect(params *nl.ConnectParams) error {
 
 	n.netstack = espstack
 
-	if n.notifyCb != nil {
-		n.notifyCb(nl.EventNetUp)
+	n.cbMu.Lock()
+	cb := n.notifyCb
+	n.cbMu.Unlock()
+	if cb != nil {
+		cb(nl.EventNetUp)
 	}
 
 	if debug {
@@ -157,7 +173,92 @@ func (n *Esplink) NetDisconnect() {
 
 // NetNotify to register callback for network events
 func (n *Esplink) NetNotify(cb func(nl.Event)) {
+	n.cbMu.Lock()
 	n.notifyCb = cb
+	n.cbMu.Unlock()
+	n.wireConnectEvents()
+}
+
+// wireConnectEvents registers a non-blocking bridge from the espradio STA
+// connect/disconnect events to the netlink notification callback, so a
+// runtime drop of the WiFi link surfaces as nl.EventNetDown. It starts a
+// single drain goroutine (idempotent via eventOnce) and re-registers the
+// espradio channel each time in case the previous registration was cleared.
+func (n *Esplink) wireConnectEvents() {
+	n.eventOnce.Do(func() {
+		n.eventCh = make(chan espradio.ConnEvent, 4)
+		go n.drainConnectEvents()
+	})
+	espradio.SetConnectEventChan(n.eventCh)
+}
+
+func (n *Esplink) drainConnectEvents() {
+	for ev := range n.eventCh {
+		if !ev.Connected {
+			n.lastReasonMu.Lock()
+			n.lastReason = ev.Reason
+			n.lastReasonMu.Unlock()
+		}
+		n.cbMu.Lock()
+		cb := n.notifyCb
+		n.cbMu.Unlock()
+		if cb == nil {
+			continue
+		}
+		if ev.Connected {
+			cb(nl.EventNetUp)
+		} else {
+			cb(nl.EventNetDown)
+		}
+	}
+}
+
+// LastDisconnectReason returns the WIFI_REASON_* code of the most recent
+// STA disconnect, or 0 if none has occurred. Useful for logging why the link
+// dropped before reconnecting.
+func (n *Esplink) LastDisconnectReason() uint8 {
+	n.lastReasonMu.Lock()
+	defer n.lastReasonMu.Unlock()
+	return n.lastReason
+}
+
+// Reconnect re-establishes the WiFi association and DHCP assignment after the
+// link dropped, reusing the already-created netstack. It must NOT be called
+// from the NetNotify callback directly (that runs in event context); spawn a
+// goroutine instead. Only the WiFi association and DHCP are re-run: Enable and
+// Start are one-shot and must not be repeated.
+func (n *Esplink) Reconnect() error {
+	if debug {
+		println("Esplink Reconnect: connecting to WiFi")
+	}
+	if err := espradio.Connect(espradio.STAConfig{
+		SSID:     n.ssid,
+		Password: n.password,
+	}); err != nil {
+		if debug {
+			println("reconnect failed:", err)
+		}
+		return err
+	}
+	if n.netstack == nil {
+		return errNotConnected
+	}
+	if debug {
+		println("Esplink Reconnect: acquiring DHCP")
+	}
+	if _, err := n.netstack.SetupWithDHCP(espradio.DHCPConfig{}); err != nil {
+		if debug {
+			println("reconnect DHCP failed:", err)
+		}
+		return err
+	}
+	n.cbMu.Lock()
+	cb := n.notifyCb
+	n.cbMu.Unlock()
+	if cb != nil {
+		cb(nl.EventNetUp)
+	}
+	return nil
 }
 
 // GetHardwareAddr returns device MAC address

--- a/radio.c
+++ b/radio.c
@@ -418,6 +418,16 @@ esp_err_t espradio_sta_set_config(const char *ssid, int ssid_len,
     memcpy(cfg.sta.password, pwd, pwd_len);
     if (pwd_len > 0)
         cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
+    /* memset above leaves pmf_cfg = {capable: false, required: false}. Many
+     * routers running WPA2/WPA3 "mixed" (transition) mode set PMF/802.11w to
+     * required globally once WPA3 is enabled at all, even for WPA2-PSK
+     * clients — a client that doesn't advertise PMF capability then fails
+     * association, observed on real hardware as WIFI_REASON_AUTH_EXPIRE
+     * ("auth expired") regardless of signal strength or retries. capable=true
+     * lets the AP's own PMF policy drive the negotiation (works against both
+     * PMF-required and PMF-disabled APs) without us forcing required=true,
+     * which would instead refuse to associate with a PMF-disabled AP. */
+    cfg.sta.pmf_cfg.capable = true;
     return esp_wifi_set_config(WIFI_IF_STA, &cfg);
 }
 

--- a/radio.go
+++ b/radio.go
@@ -626,6 +626,15 @@ func Start() error {
 	// the TX frame queues may be in an inconsistent state when those PM
 	// callbacks run, causing NULL-pointer crashes in ppCheckIsConnTraffic.
 	//
+	// Re-enabling power save (WIFI_PS_MIN_MODEM after a confirmed-successful
+	// Connect(), with both ppCheckTxConnTrafficIdle and ppCheckIsConnTraffic
+	// wrapped to safe stubs) was tried and reverted: it produced consistent
+	// "auth expired" connect failures on real hardware even with power save
+	// also forced to WIFI_PS_NONE for the whole probe/auth/assoc handshake,
+	// so the actual cause is still unidentified — not confirmed to be power
+	// save timing at all. Revisit with real-hardware bisection before trying
+	// again.
+	//
 	// Pump the scheduler so ppTask processes the START command (pp_attach,
 	// ppInitTxq, etc.) and the critical ROM pointer variables (pTxRx,
 	// our_tx_eb, …) get initialised, then snapshot them.
@@ -957,6 +966,69 @@ var (
 	connectResult chan ConnectResult
 )
 
+// ConnEvent describes a change in the STA link state, delivered to the
+// callback registered with SetConnectEventCallback. It fires on every
+// connect/disconnect, including after association (not just during a blocking
+// Connect call), so a firmware can detect the network going down at runtime.
+type ConnEvent struct {
+	Connected bool   // true on association, false on disconnect
+	Reason    uint8  // WIFI_REASON_* code; only meaningful when Connected==false
+	SSID      string // AP SSID (populated on connect)
+	Channel   uint8  // AP channel (populated on connect)
+}
+
+var (
+	eventCbMu   sync.Mutex
+	eventCb     func(ConnEvent)
+	eventCbChan chan ConnEvent
+)
+
+// SetConnectEventCallback registers a callback invoked from the WiFi event
+// path on every STA connect/disconnect. Only one callback is retained; pass
+// nil to clear it. The callback runs in event context (C path via osi.c), so
+// it MUST NOT block; at most signal a channel/flag for a separate goroutine to
+// act on. Use SetConnectEventChan as a non-blocking alternative.
+func SetConnectEventCallback(cb func(ConnEvent)) {
+	if cb == nil {
+		return
+	}
+	eventCbMu.Lock()
+	eventCb = cb
+	eventCbChan = nil
+	eventCbMu.Unlock()
+}
+
+// SetConnectEventChan registers a non-blocking channel that receives ConnEvent
+// on every STA connect/disconnect. Events are dropped (not blocking) when the
+// channel is full. Pass nil to clear it. At most one of callback/channel is
+// active; the most recent registration wins.
+func SetConnectEventChan(ch chan ConnEvent) {
+	eventCbMu.Lock()
+	eventCb = nil
+	eventCbChan = ch
+	eventCbMu.Unlock()
+}
+
+// fireConnectEvent delivers a ConnEvent to whichever sink (callback or
+// channel) is currently registered. Must be called from the event handler; it
+// never blocks the caller.
+func fireConnectEvent(ev ConnEvent) {
+	eventCbMu.Lock()
+	cb := eventCb
+	ch := eventCbChan
+	eventCbMu.Unlock()
+	if cb != nil {
+		cb(ev)
+		return
+	}
+	if ch != nil {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
 // Connect configures STA credentials and initiates association.
 // Blocks until CONNECTED, DISCONNECTED or timeout.
 func Connect(cfg STAConfig) error {
@@ -1022,6 +1094,7 @@ func espradio_on_wifi_event(eventID int32, data unsafe.Pointer) {
 			default:
 			}
 		}
+		fireConnectEvent(ConnEvent{Connected: true, SSID: string(ssid), Channel: uint8(ev.channel)})
 
 	case C.WIFI_EVENT_STA_DISCONNECTED:
 		C.espradio_netif_set_connected(0)
@@ -1035,6 +1108,7 @@ func espradio_on_wifi_event(eventID int32, data unsafe.Pointer) {
 			default:
 			}
 		}
+		fireConnectEvent(ConnEvent{Connected: false, Reason: uint8(ev.reason)})
 
 	case C.WIFI_EVENT_STA_START:
 	}

--- a/radio.go
+++ b/radio.go
@@ -592,8 +592,16 @@ func Enable(config Config) error {
 	schedOnce()
 	C.espradio_netif_init_netstack_cb()
 
-	// set default transmit level of 20 dBm (100 mW) for ESP32.
-	C.esp_wifi_set_max_tx_power(C.int8_t(20))
+	// Set a conservative static TX-power ceiling as a fallback for any path
+	// that never reaches a successful Connect(). At full power the classic
+	// ESP32's PA saturates and distorts the signal (poor EVM), which makes APs
+	// reject the association as WIFI_REASON_AUTH_EXPIRE ("auth expired") even
+	// with correct credentials and strong RSSI. Connect() re-applies this same
+	// floor before every handshake and only raises it afterward, from the
+	// adaptive value derived from the connected AP's RSSI (see
+	// SetAdaptiveTXPower). This caps the per-rate maxima baked into the PHY
+	// init data table, so no table edit is required.
+	C.esp_wifi_set_max_tx_power(dbmToQuarterDBm(adaptiveTX.minPower))
 
 	return nil
 }
@@ -1029,12 +1037,136 @@ func fireConnectEvent(ev ConnEvent) {
 	}
 }
 
+// ─── Adaptive TX power ────────────────────────────────────────────────────────
+
+// Adaptive TX power sets the STA's maximum transmit power from the signal
+// strength of the associated AP.  At full power the classic ESP32's PA
+// saturates and distorts the signal (poor EVM), which makes APs reject the
+// association as WIFI_REASON_AUTH_EXPIRE ("auth expired") even with correct
+// credentials and strong RSSI.  A nearby AP (strong downlink RSSI) needs far
+// less power, so backing off keeps the link clean.  The adjustment runs once
+// per successful connect, reading the live RSSI of the connected AP.
+var adaptiveTX = struct {
+	enabled  bool
+	minPower int8
+	maxPower int8
+}{enabled: true, minPower: 8, maxPower: 20}
+
+// SetAdaptiveTXPower enables or disables automatic TX-power adjustment and sets
+// the power bounds (dBm) the adjustment may select.  When enabled (the
+// default), Connect() reads the associated AP's RSSI and picks a TX power
+// within the bounds: a strong (nearby) AP gets a low value, a weak AP the
+// upper bound.  Values outside the ESP32's 2-20 dBm range (esp_wifi.h
+// esp_wifi_set_max_tx_power: "range is [8, 84]" in 0.25 dBm units) are
+// clamped.
+//
+// Set it before Connect()/Reconnect(); it is read on the connect path and not
+// synchronized with it, so changing it mid-connect has no defined effect on
+// the in-flight association.
+func SetAdaptiveTXPower(enabled bool, minPower, maxPower int8) {
+	if minPower < 2 {
+		minPower = 2
+	}
+	if maxPower > 20 {
+		maxPower = 20
+	}
+	if minPower > maxPower {
+		minPower = maxPower
+	}
+	adaptiveTX.enabled = enabled
+	adaptiveTX.minPower = minPower
+	adaptiveTX.maxPower = maxPower
+}
+
+// dbmToQuarterDBm converts a whole-dBm power to the 0.25 dBm units
+// esp_wifi_set_max_tx_power actually takes (esp_wifi.h: "Param power unit is
+// 0.25dBm, range is [8, 84] corresponding to 2dBm - 20dBm"), clamping to that
+// hardware-supported range. Passing a raw dBm value here uncorrected — as
+// this file used to — silently asks for a quarter of the intended power.
+func dbmToQuarterDBm(dbm int8) C.int8_t {
+	q := int32(dbm) * 4
+	switch {
+	case q < 8:
+		q = 8
+	case q > 84:
+		q = 84
+	}
+	return C.int8_t(q)
+}
+
+// setTXPowerFloor lowers the max TX power to the conservative floor before an
+// auth/assoc attempt. Called at the start of Connect(), because
+// applyAdaptiveTXPower only runs after a successful association (it needs
+// esp_wifi_sta_get_ap_info, which requires already being associated) — so
+// without this, a reconnect following a prior connection to a weak/distant AP
+// (which raised power toward maxPower) would start its handshake at that
+// stale, still-elevated power instead of the safe floor, reintroducing the
+// same PA-saturation risk this whole mechanism exists to avoid.
+func setTXPowerFloor() {
+	if !adaptiveTX.enabled {
+		return
+	}
+	C.esp_wifi_set_max_tx_power(dbmToQuarterDBm(adaptiveTX.minPower))
+}
+
+// connectedAPRSSI returns the RSSI (dBm) of the currently associated AP, or
+// false if it cannot be queried (not connected / blob rejects the call).
+func connectedAPRSSI() (int8, bool) {
+	C.espradio_ensure_osi_ptr()
+	var rec C.wifi_ap_record_t
+	if code := C.esp_wifi_sta_get_ap_info(&rec); code != C.ESP_OK {
+		return 0, false
+	}
+	return int8(rec.rssi), true
+}
+
+// adaptiveTXPower maps a downlink RSSI to a TX power.  RSSI is reported by the
+// STA and represents the AP's signal as heard on this side, a reliable proxy
+// for distance on a symmetric 2.4 GHz link.
+func adaptiveTXPower(rssi int8) int8 {
+	var p int8
+	switch {
+	case rssi >= -50:
+		p = 8
+	case rssi >= -65:
+		p = 12
+	case rssi >= -75:
+		p = 16
+	default:
+		p = adaptiveTX.maxPower
+	}
+	if p < adaptiveTX.minPower {
+		p = adaptiveTX.minPower
+	}
+	if p > adaptiveTX.maxPower {
+		p = adaptiveTX.maxPower
+	}
+	return p
+}
+
+// applyAdaptiveTXPower reads the connected AP's RSSI and sets the max TX power
+// accordingly.  Called from Connect() on a successful association.
+func applyAdaptiveTXPower() {
+	if !adaptiveTX.enabled {
+		return
+	}
+	rssi, ok := connectedAPRSSI()
+	if !ok {
+		return
+	}
+	C.esp_wifi_set_max_tx_power(dbmToQuarterDBm(adaptiveTXPower(rssi)))
+}
+
 // Connect configures STA credentials and initiates association.
 // Blocks until CONNECTED, DISCONNECTED or timeout.
 func Connect(cfg STAConfig) error {
 	connectMu.Lock()
 	connectResult = make(chan ConnectResult, 1)
 	connectMu.Unlock()
+
+	// Must run before esp_wifi_connect_internal, not just once in Enable():
+	// see setTXPowerFloor's comment for why a reconnect needs this too.
+	setTXPowerFloor()
 
 	code := C.espradio_sta_set_config(
 		C.CString(cfg.SSID), C.int(len(cfg.SSID)),
@@ -1066,6 +1198,7 @@ func Connect(cfg STAConfig) error {
 			if connectReadyAfterPass == 0 {
 				connectReadyAfterPass = readyNeverSentinel
 			}
+			applyAdaptiveTXPower()
 			return nil
 		}
 		return makeError(C.esp_err_t(res.Reason))


### PR DESCRIPTION
Found by cross-checking against the real esp-idf sources after "auth expired" failures on classic ESP32 that didn't reproduce on every connect attempt.

- esp32/esp32.go: espradio_hal_init_clocks_go only enabled the WiFi clock gate. Real esp_wifi_bt_power_domain_on() (esp-idf components/esp_phy/src/phy_init.c) also releases WIFI_FORCE_PD, pulses the modem reset on DPORT.CORE_RST_EN, and releases WIFI_FORCE_ISO — classic ESP32 has SOC_PM_MODEM_PD_BY_SW=1, unlike ESP32-C6, so this isn't a no-op here. Harmless on a cold boot (ROM leaves those bits clear already) but wrong after anything that sets them. Also fixes espradio_hal_read_mac_go's MAC byte order to match efuse_hal_get_mac()'s plain little-endian store (was byte-reversed — same bug found and fixed on ESP32-C3/C6 this session, copied across ports instead of derived from esp-idf).
- radio.c: espradio_sta_set_config left pmf_cfg.capable false. Some routers running WPA2/WPA3 mixed mode require PMF globally once WPA3 is enabled at all, even for WPA2-PSK clients; a client that doesn't advertise PMF capability fails association with WIFI_REASON_AUTH_EXPIRE regardless of signal or retries. capable=true lets the AP's own policy drive negotiation without forcing required=true (which would instead refuse a PMF-disabled AP).
- netif.c: documents a reverted experiment (re-enabling WIFI_PS_MIN_MODEM + wrapping ppCheckIsConnTraffic) that produced consistent auth failures on real hardware, so the next person doesn't retry the same combination.

- radio.go/netlink: adds ConnEvent, SetConnectEventCallback/Chan, and Esplink.Reconnect so a firmware can detect a runtime WiFi drop (nl.EventNetDown) and re-associate + re-run DHCP without a reboot, reusing the existing netstack/netdev (StartNetDev only registers the RX pump and isn't torn down on disconnect; espradio_netif_set_connected just gates TX and is re-armed synchronously inside a successful Connect()).